### PR TITLE
Add alembic revision to change dtype of 'name' col in 'source' table

### DIFF
--- a/backend/app/alembic/versions/87634be1fc8a_fix_source_table_column_type.py
+++ b/backend/app/alembic/versions/87634be1fc8a_fix_source_table_column_type.py
@@ -1,0 +1,25 @@
+"""fix source table column type
+
+Revision ID: 87634be1fc8a
+Revises: 9ef4aeb8094f
+Create Date: 2022-01-10 02:47:12.512491-08:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "87634be1fc8a"
+down_revision = "9ef4aeb8094f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Change "name" column in "source" table from CHAR to VARCHAR
+    op.alter_column("source", "name", type_=sa.VARCHAR(length=128))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Added an alembic revision to change the data type of the `name` column in the `source` table from *character* to *character varying (128)*. This means that trailing spaces are now not stored in this column.

Inspecting the table contents in pgAdmin seems to show that now only the 4 characters of 'CCLW' are stored for the source we have in there at the moment.
