### PR TITLE
Github actions integration for parsing pipeline tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,26 +11,26 @@ on:
       - dev
 
 jobs:
-  # test:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Build docker-compose stack using .env.example
-  #       run: cp .env.example .env && make build
-  #     - name: verify backend is up
-  #       run: curl http://localhost:8000/api/docs
-  #     - name: Run backend tests
-  #       run: make test_backend
-  #     - name: docker
-  #       run: |
-  #         docker-compose logs
-  #         docker-compose ps
-  #         docker ps -a
-  #         ls -la
-  #     - name: verify frontend is up
-  #       run: curl http://localhost:3000
-  #     - name: Run frontend tests
-  #       run: make test_frontend
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build docker-compose stack using .env.example
+        run: cp .env.example .env && make build
+      - name: verify backend is up
+        run: curl http://localhost:8000/api/docs
+      - name: Run backend tests
+        run: make test_backend
+      - name: docker
+        run: |
+          docker-compose logs
+          docker-compose ps
+          docker ps -a
+          ls -la
+      - name: verify frontend is up
+        run: curl http://localhost:3000
+      - name: Run frontend tests
+        run: make test_frontend
   test_pipeline:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
   test_pipeline:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - uses: webfactory/ssh-agent@v0.5.4
         with:
             ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,12 @@ jobs:
   test_pipeline:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup SSH Keys and known_hosts
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: 
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}      
       - name: Build pipeline
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: make build_pipeline
+        run: cd pipeline && eval $(ssh-agent) && DOCKER_BUILDKIT=1 docker build --ssh default -t navigator_pipeline .
       - name: Test pipeline
         run: make test_pipeline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,23 +11,39 @@ on:
       - dev
 
 jobs:
-  test:
+  # test:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Build docker-compose stack using .env.example
+  #       run: cp .env.example .env && make build
+  #     - name: verify backend is up
+  #       run: curl http://localhost:8000/api/docs
+  #     - name: Run backend tests
+  #       run: make test_backend
+  #     - name: docker
+  #       run: |
+  #         docker-compose logs
+  #         docker-compose ps
+  #         docker ps -a
+  #         ls -la
+  #     - name: verify frontend is up
+  #       run: curl http://localhost:3000
+  #     - name: Run frontend tests
+  #       run: make test_frontend
+  test_pipeline:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build docker-compose stack using .env.example
-        run: cp .env.example .env && make build
-      - name: verify backend is up
-        run: curl http://localhost:8000/api/docs
-      - name: Run backend tests
-        run: make test_backend
-      - name: docker
-        run: |
-          docker-compose logs
-          docker-compose ps
-          docker ps -a
-          ls -la
-      - name: verify frontend is up
-        run: curl http://localhost:3000
-      - name: Run frontend tests
-        run: make test_frontend
+      - name: Setup SSH Keys and known_hosts
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: 
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
+      - name: Build pipeline
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: make build_pipeline
+      - name: Test pipeline
+        run: make test_pipeline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-            ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}      
       - name: Build pipeline
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: cd pipeline && DOCKER_BUILDKIT=1 docker build -t navigator_pipeline .
+        run: make build_pipeline
       - name: Test pipeline
         run: make test_pipeline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,16 @@ jobs:
   test_pipeline:
     runs-on: ubuntu-latest
     steps:
-      - uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}      
+      - uses: actions/checkout@v2
+      - name: Setup SSH Keys and known_hosts
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: 
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
       - name: Build pipeline
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: make build_pipeline
       - name: Test pipeline
         run: make test_pipeline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Build pipeline
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: cd pipeline && eval $(ssh-agent) && DOCKER_BUILDKIT=1 docker build --ssh default -t navigator_pipeline .
+        run: make build_pipeline
       - name: Test pipeline
         run: make test_pipeline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,10 @@ jobs:
   test_pipeline:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup SSH Keys and known_hosts
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: 
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
+      - uses: webfactory/ssh-agent@v0.5.4
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}      
       - name: Build pipeline
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: make build_pipeline
       - name: Test pipeline
         run: make test_pipeline

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Build pipeline
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: make build_pipeline
+        run: cd pipeline && DOCKER_BUILDKIT=1 docker build -t navigator_pipeline .
       - name: Test pipeline
         run: make test_pipeline

--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -31,7 +31,7 @@ test:
 
 # pipeline
 build_pipeline:
-	cd pipeline && eval $(ssh-agent) && DOCKER_BUILDKIT=1 docker build --ssh default -t navigator_pipeline .
+	cd pipeline && DOCKER_BUILDKIT=1 docker build -t navigator_pipeline .
 
 test_pipeline:
 	docker run navigator_pipeline python -m pytest

--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -31,7 +31,7 @@ test:
 
 # pipeline
 build_pipeline:
-	cd pipeline && DOCKER_BUILDKIT=1 docker build -t navigator_pipeline .
+	cd pipeline && docker build -t navigator_pipeline .
 
 test_pipeline:
 	docker run navigator_pipeline python -m pytest

--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -31,7 +31,7 @@ test:
 
 # pipeline
 build_pipeline:
-	cd pipeline && DOCKER_BUILDKIT=1 docker build -t navigator_pipeline .
+	cd pipeline && eval $(ssh-agent) && DOCKER_BUILDKIT=1 docker build --ssh default -t navigator_pipeline .
 
 test_pipeline:
 	docker run navigator_pipeline python -m pytest

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -9,9 +9,8 @@ RUN apt update && \
 RUN mkdir ~/.ssh
 RUN ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 RUN git clone https://github.com/kermitt2/pdfalto.git
-# Set all submodule URLs to HTTPS to avoid need for SSH setup when run on a server
-RUN cd pdfalto && perl -i -p -e 's|https://(.*?)/|git@\1:|g' .gitmodules
-RUN cd pdfalto && git submodule update --init --recursive
+# Set submodule URL to HTTPS to avoid need for SSH setup when run on a server
+RUN cd pdfalto && git submodule set-url xpdf-4.03 https://github.com/kermitt2/xpdf-4.03.git && git submodule update --init --recursive
 RUN cd pdfalto && cmake .
 RUN cd pdfalto && make
 

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -9,8 +9,9 @@ RUN apt update && \
 RUN mkdir ~/.ssh
 RUN ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 RUN git clone https://github.com/kermitt2/pdfalto.git
-# Set submodule URL to HTTPs to avoid need for SSH setup when run on a server
-RUN cd pdfalto && git submodule set-url xpdf-4.03 https://github.com/kermitt2/xpdf-4.03.git && git submodule update --init --recursive
+# Set all submodule URLs to HTTPS to avoid need for SSH setup when run on a server
+RUN cd pdfalto && perl -i -p -e 's|https://(.*?)/|git@\1:|g' .gitmodules
+RUN cd pdfalto && git submodule update --init --recursive
 RUN cd pdfalto && cmake .
 RUN cd pdfalto && make
 

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -9,8 +9,8 @@ RUN apt update && \
 RUN mkdir ~/.ssh
 RUN ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 RUN git clone https://github.com/kermitt2/pdfalto.git
+# Set submodule URL to HTTPs to avoid need for SSH setup when run on a server
 RUN cd pdfalto && git submodule set-url xpdf-4.03 https://github.com/kermitt2/xpdf-4.03.git && git submodule update --init --recursive
-# RUN --mount=type=ssh cd pdfalto && git submodule update --init --recursive
 RUN cd pdfalto && cmake .
 RUN cd pdfalto && make
 

--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -9,7 +9,8 @@ RUN apt update && \
 RUN mkdir ~/.ssh
 RUN ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 RUN git clone https://github.com/kermitt2/pdfalto.git
-RUN --mount=type=ssh cd pdfalto && git submodule update --init --recursive
+RUN cd pdfalto && git submodule set-url xpdf-4.03 https://github.com/kermitt2/xpdf-4.03.git && git submodule update --init --recursive
+# RUN --mount=type=ssh cd pdfalto && git submodule update --init --recursive
 RUN cd pdfalto && cmake .
 RUN cd pdfalto && make
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -4,27 +4,11 @@ The pdf2text cli allows you to automatically extract the text from a set of pdf 
 
 ## Using the docker image
 
-### Prerequisites
+### 1. Building the docker image
 
-To clone the pdfalto Github repo, you need a machine that's configured to connect to Github via SSH. To set this up follow these steps from the Github docs:
+`docker build -t navigator_pipeline .`
 
-1. [Generate an SSH key and add it to the SSH agent](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
-2. [Add the SSH key to your Github account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
-
-On Ubuntu you may need to start the SSH agent using `eval $(ssh-agent)`.
-
-### 1. Add ssh private key to agent
-First, add your ssh private key to the ssh agent:
-
-`ssh-add`
-
-### 2. Building the docker image
-When building the docker image, you must make sure that Docker is configured to use the new [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/). This is to enable you to use [ssh to clone the pdfalto git repo](https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds).
-
-
-`DOCKER_BUILDKIT=1 docker build --ssh default -t navigator_pipeline .`
-
-### 3. Running the cli
+### 2. Running the cli
 Use the following command to run the pdf2text cli:
 
 ```


### PR DESCRIPTION
Integrated unit tests for the PDF parsing pipeline into the Github Actions CI process. Closes #349.

I had some issues enabling SSH access from Github actions to Github so `git submodule update` could be run, so instead changed the Dockerfile to use the HTTPS URL for the `xpdf-4.03` submodule. This also means that there is no buildkit dependency for Docker, and the readme has become a lot simpler.