### PR TITLE
Adobe Embed API - annotation with bounding boxes

### DIFF
--- a/pipeline/extract/document.py
+++ b/pipeline/extract/document.py
@@ -89,6 +89,32 @@ class Page:
 
         return "\n".join(page_text)
 
+    def flip_y_coordinates(self) -> "Page":
+        """Flip the y-coordinates of the text blocks in the page, so that the point (0,0) moves from the top left of the page to the bottom left of the page.
+
+        This is useful for the Adobe Embed API.
+        """
+
+        page_height = self.dimensions[1]
+
+        flipped_text_blocks = [
+            TextBlock(
+                text=text_block.text,
+                text_block_id=text_block.text_block_id,
+                coords=[(x, page_height - y) for x, y in text_block.coords],
+                type=text_block.type,
+                path=text_block.path,
+                custom_attributes=text_block.custom_attributes,
+            )
+            for text_block in self.text_blocks
+        ]
+
+        return Page(
+            text_blocks=flipped_text_blocks,
+            dimensions=self.dimensions,
+            page_id=self.page_id,
+        )
+
 
 @dataclass
 class Document:


### PR DESCRIPTION
**Update: I've added these details [to Notion](https://www.notion.so/climatepolicyradar/Adobe-PDF-Embed-API-bounding-box-highlighting-4d8a60d2f00b44558cb25358ce0d333d) too**

This PR adds a new postprocessor which flips the coordinate system used for text block coordinates so that the origin is on the bottom left of each page, as this is what's required by the Adobe Embed API. Note there are some other small code changes but these were just to get the pre-commit checks to pass.

I've also forked a codepen showing how we can add multiple bounding box annotations to one PDF based on bounding boxes.

* [codepen with working example](https://codepen.io/kdutia/pen/QWaVVdO)
* [Adobe Embed API annotation docs](https://developer.adobe.com/document-services/docs/overview/pdf-embed-api/howtos_comments/#annotation-schema)
* [helpful article](https://medium.com/adobetech/adding-annotations-to-a-pdf-using-adobe-pdf-embed-api-fb6f85da4c02) (view in private browsing to bypass medium's paywall)

**Screenshot of codepen output.** Note the sidebar is optional and can be disabled by setting `showCommentsPanel: false`

![image](https://user-images.githubusercontent.com/20212179/163207834-606060d5-917a-48f1-a5f6-0941cac499b7.png)


I have the following **outstanding question**:
* the Embed API requires coordinates in two different formats: a bounding box (`[Xmin, Ymin, Xmax, Ymax]`) and a set of rectangles to draw within that bounding box, which for our purpose is the same rectangle but needs to be defined using the format `[Xmin, Ymin, Xmax, Ymin, Xmax, Ymax, Xmin, Ymax]`. At the moment through the API we provide the latter but not the former. Should we also provide the simplified coordinates through Opensearch, or will this be easy enough to do on the front end?
