### PR TITLE
Pipeline doesn't fall over when pdfalto fails

### DIFF
--- a/pipeline/pdf2text.py
+++ b/pipeline/pdf2text.py
@@ -186,11 +186,16 @@ class PDFProcessor:
                 f"Adobe extractor failed with error {e} for {pdf_filename}. Falling back to embedded text extractor."
             )
 
-            pdf_doc = self.embedded_extractor.extract(
-                pdf_filepath=pdf_filepath,
-                pdf_name=pdf_filename,
-                data_output_dir=self.data_dir,
-            )
+            try:
+                pdf_doc = self.embedded_extractor.extract(
+                    pdf_filepath=pdf_filepath,
+                    pdf_name=pdf_filename,
+                    data_output_dir=self.data_dir,
+                )
+            except Exception as e:
+                print(
+                    f"Embedded extractor also failed with error {e} for {pdf_filename}."
+                )
 
         save_filename = Path(pdf_filename).stem
 


### PR DESCRIPTION
When adobe fails, the pdf2text pipeline tries to use pdfalto. Before, if pdfalto failed, it stopped pdf processing, which was annoying. Now it just logs the double failure for inspection later.