### PR TITLE
Include md5 hash of content in PDF filename

### DIFF
--- a/loader/app/service/api_client.py
+++ b/loader/app/service/api_client.py
@@ -8,6 +8,7 @@ Then delete this later.
 import os
 from functools import lru_cache
 from typing import Callable
+import hashlib
 
 import requests
 
@@ -113,12 +114,22 @@ def upload_document(source_url: str, file_name_without_suffix: str) -> str:
     download_response = requests.get(source_url)
     content_type = download_response.headers["Content-Type"]
     file_content = download_response.content
+    file_content_hash = hashlib.md5(file_content).hexdigest()
 
     # determine the remote file name, including folder structure
+    parts = file_name_without_suffix.split("-")
+    folder_path = parts[0] + "/" + parts[1] + "/"
     file_suffix = content_type.split("/")[1]
-    file_name = f"{file_name_without_suffix}.{file_suffix}"
 
-    parts = file_name.split("-")
+    # s3 can only handle paths of up to 1024 bytes. To ensure we don't exceed that,
+    # we trim the filename if it's too long
+    filename_max_len = (
+        1024 - len(folder_path) - len(file_suffix) - len(file_content_hash) - len("_.")
+    )
+    file_name_without_suffix_trimmed = file_name_without_suffix[:filename_max_len]
+
+    file_name = f"{file_name_without_suffix_trimmed}_{file_content_hash}.{file_suffix}"
+
     # puts docs in folder <country_code>/<publication_year>/<file_name>
     full_path = parts[0] + "/" + parts[1] + "/" + file_name
 


### PR DESCRIPTION
Another tiny Friday PR: add md5 hashes of the PDF to the filenames in s3. Document names are trimmed if the total s3 path exceeds 1024 bytes.

Path example:
```
AFG/2008/AFG-2008-12-25-Energy+Sector+Strategy+1387-1391+%282007_8-2012_3%29-1_32f2e641f0078956c0baa4c48d0a6b28.pdf
```

I'm only getting the first 11 docs in the data loaded in, guessing because of some local issue. When I've got it sorted I'll reupload all PDFs to s3 which will complete #431.