### PR TITLE
Minor robustness improvements for loader

### DIFF
--- a/loader/app/loaders/loader_cclw_v2/load/main.py
+++ b/loader/app/loaders/loader_cclw_v2/load/main.py
@@ -48,8 +48,10 @@ async def load(ctx: Context, policies: PolicyLookup):
     for key, policy_data in policies.items():
         task = asyncio.ensure_future(save_action(ctx, key, policy_data))
         tasks.append(task)
-        if len(tasks) > 1:
-            break
+
+        # -- for debugging
+        # if len(tasks) > 1:
+        #     break
 
     doc_counts = await asyncio.gather(
         *tasks,

--- a/loader/app/main.py
+++ b/loader/app/main.py
@@ -81,7 +81,9 @@ async def main():
     data = extract(csv_file)
     policies = transform(data)  # noqa: F841
     for db in get_db():
-        async with httpx.AsyncClient(transport=transport, timeout=10) as client:
+        # This timeout is large because there are some very large PDFs we need to upload
+        # TODO: how do we deal with the fact that we have massive PDFs with big loading times in the frontend?
+        async with httpx.AsyncClient(transport=transport, timeout=120) as client:
             ctx = Context(
                 db=db,
                 client=client,

--- a/loader/app/service/document_upload.py
+++ b/loader/app/service/document_upload.py
@@ -27,6 +27,12 @@ async def upload_all_documents(ctx: Context):
         country_code = get_country_code_from_geography_id(document_db.geography_id)
         publication_date = event.created_ts.date().isoformat()
 
+        if document_db.url:
+            logger.info(
+                f"Skipping upload for {document_db.source_url} as already uploaded"
+            )
+            continue
+
         logger.debug(f"Uploading {document_db.source_url} to {document_db.url}")
         # TODO: make document upload more resilient
         try:


### PR DESCRIPTION
- comment out debugging limit
- skips attempting upload to s3 if document already has a `url`
- 