### PR TITLE
Loader fixes

### DIFF
--- a/loader/app/loaders/loader_cclw_v2/transform/util.py
+++ b/loader/app/loaders/loader_cclw_v2/transform/util.py
@@ -56,10 +56,10 @@ def get_policy_data(
         document_type = dataframe["document_type"]
         events = extract_events(dataframe["events"])
         sectors = prune(dataframe["sectors"].split(";"))
-        instruments = prune(dataframe["instruments"].split("|"))
-        frameworks = prune(dataframe["frameworks"].split(","))
-        responses = prune(dataframe["responses"].split(","))
-        hazards = prune(dataframe["hazards"].split(","))
+        instruments = prune(dataframe["instruments"].split(";"))
+        frameworks = prune(dataframe["frameworks"].split(";"))
+        responses = prune(dataframe["responses"].split(";"))
+        hazards = prune(dataframe["hazards"].split(";"))
         keywords = prune(dataframe["keywords"].split(";"))
         year = dataframe["document_year"]
 

--- a/loader/app/poster/post.py
+++ b/loader/app/poster/post.py
@@ -100,7 +100,7 @@ def post_doc(db: Session, doc: Document) -> dict:
             "source_id": doc.source_id,
             "geography_id": doc.geography_id,  # this is from backend API lookup, so will exist remotely.
             "category_id": doc.category_id,  # this is from backend API lookup, so will exist remotely.
-            "publication_ts": doc.publication_ts,
+            "publication_ts": doc.publication_ts.isoformat(),
         },
         "source_id": doc.source_id,
         "events": [it.as_dict() for it in events],


### PR DESCRIPTION
Found a couple of bugs where the some metadata fields were wrongly split from the CSV, and posting documents from the loader DB to the API DB was failing.