### PR TITLE
Non-pdf UI changes

### DIFF
--- a/frontend/src/components/blocks/SearchResult.tsx
+++ b/frontend/src/components/blocks/SearchResult.tsx
@@ -16,28 +16,20 @@ const SearchResult = ({ document, onClick }: SearchResultProps) => {
       <div className="flex justify-between items-start">
         <h2 className="leading-none flex items-start">
           <button
-            onClick={onClick}
+            onClick={() => router.push(`/document/${document.document_id}`)}
             className="text-left text-blue-500 font-medium text-lg transition duration-300 hover:text-indigo-600 leading-tight"
           >
             {truncateString(document.document_name, 80)}
           </button>
         </h2>
-
-        <div className="flex pl-2">
-          {/* TODO: need pdf url */}
-          <button
-            className="text-indigo-500 hover:text-indigo-600 transition duration-300"
-            onClick={() => router.push(`/pdf/${document.document_id}`)}
-          >
-            <DownloadPDFIcon height="24" width="24" />
-          </button>
-          <button
-            className="text-indigo-500 hover:text-indigo-600 transition duration-300 ml-2"
-            onClick={() => router.push(`/document/${document.document_id}`)}
-          >
-            <ViewDocumentCoverPageIcon height="24" width="24" />
-          </button>
-        </div>
+        {document.content_type === 'application/pdf' && (
+          <div className="flex pl-2">
+            <a target="_blank" href={document.document_url}>
+              <span className="sr-only">Download PDF</span>
+              <DownloadPDFIcon height="24" width="24" />
+            </a>
+          </div>
+        )}
       </div>
 
       <div className="flex text-xs text-indigo-400 mt-3">
@@ -63,14 +55,17 @@ const SearchResult = ({ document, onClick }: SearchResultProps) => {
         )}
       </p>
       {/* TODO: translate below text, how to handle plurals? */}
-      <button
-        className="text-indigo-500 underline text-sm mt-3 transition duration-300 hover:text-indigo-600"
-        onClick={onClick}
-      >
-        {document.document_passage_matches.length} match
-        {`${document.document_passage_matches.length === 1 ? '' : 'es'}`} in
-        document
-      </button>
+      {document.document_passage_matches.length > 0 &&
+        document.content_type === 'application/pdf' && (
+          <button
+            className="text-indigo-500 underline text-sm mt-3 transition duration-300 hover:text-indigo-600"
+            onClick={onClick}
+          >
+            {document.document_passage_matches.length} match
+            {`${document.document_passage_matches.length === 1 ? '' : 'es'}`} in
+            document
+          </button>
+        )}
     </div>
   );
 };

--- a/frontend/src/components/blocks/SearchResult.tsx
+++ b/frontend/src/components/blocks/SearchResult.tsx
@@ -22,14 +22,14 @@ const SearchResult = ({ document, onClick }: SearchResultProps) => {
             {truncateString(document.document_name, 80)}
           </button>
         </h2>
-        {document.content_type === 'application/pdf' && (
+        {/* {document.content_type === 'application/pdf' && (
           <div className="flex pl-2">
             <a target="_blank" href={document.document_url}>
               <span className="sr-only">Download PDF</span>
               <DownloadPDFIcon height="24" width="24" />
             </a>
           </div>
-        )}
+        )} */}
       </div>
 
       <div className="flex text-xs text-indigo-400 mt-3">

--- a/frontend/src/pages/document/[docId].tsx
+++ b/frontend/src/pages/document/[docId].tsx
@@ -12,6 +12,7 @@ import useDocumentDetail from '../../hooks/useDocumentDetail';
 import RelatedDocument from '../../components/blocks/RelatedDocument';
 import Tooltip from '../../components/tooltip';
 import { convertDate } from '../../utils/timedate';
+import { DownloadPDFIcon } from '../../components/svg/Icons';
 
 const DocumentCoverPage = () => {
   const [showFullSummary, setShowFullSummary] = useState(false);
@@ -56,17 +57,14 @@ const DocumentCoverPage = () => {
         </div>
       ) : (
         // TODO: translate all UI text
-        <section className="mb-8">
+        <section className="mt-4 mb-8">
           <div className="container">
             <TextLink href="/search">
-              <span className="text-lg">&laquo;</span>Back to search results
-            </TextLink>{' '}
-            <span className="mx-1">|</span>
-            <TextLink target="_blank" href={page.url}>
-              Download PDF
+              <span>&laquo;</span> Back to search results
             </TextLink>
+
             <h1 className="mt-6 text-3xl font-medium">{page.name}</h1>
-            <div className="flex text-xs text-indigo-400 mt-3">
+            <div className="flex text-xs text-indigo-400 mt-3 items-center w-full">
               <div
                 className={`rounded-sm border border-black flag-icon-background flag-icon-${page.geography.value.toLowerCase()}`}
               />
@@ -84,6 +82,19 @@ const DocumentCoverPage = () => {
                   tooltip="The year in which the document was first published"
                 />
               </div>
+              {page.content_type === 'application/pdf' && (
+                <div className="ml-6">
+                  <a
+                    target="_blank"
+                    className="bg-blue-500 rounded-full py-2 px-4 text-white flex items-center transition duration-300 hover:bg-indigo-600"
+                    href={page.url}
+                  >
+                    <span className="sr-only">Download PDF</span>
+                    <DownloadPDFIcon height="24" width="24" />{' '}
+                    <span className="ml-1">Download</span>
+                  </a>
+                </div>
+              )}
             </div>
             <div className="md:flex">
               <section className="flex-1">
@@ -134,7 +145,7 @@ const DocumentCoverPage = () => {
                   </section>
                 ) : null}
               </section>
-              <section className="border-l border-blue-100 pl-4 mt-6 md:w-2/5 lg:w-4/12 md:ml-12 flex-shrink-0">
+              <section className="md:border-l md:border-blue-100 md:pl-4 mt-6 md:w-2/5 lg:w-4/12 md:ml-12 flex-shrink-0">
                 <h3 className="text-xl text-indigo-400">
                   Further information about this document
                 </h3>
@@ -151,46 +162,59 @@ const DocumentCoverPage = () => {
                   text={page.type.name}
                 />
                 {/* Topics maps to responses */}
-                <DocumentInfo
-                  id="topics-tt"
-                  tooltip="Broad areas of climate action contained in the document, e.g. mitigation or adaptation. For more information, see our Methodology page"
-                  heading="Topics"
-                  list={page.topics}
-                />
-                <DocumentInfo
-                  heading="Language"
-                  text={page.languages[0].name}
-                />
-                <DocumentInfo
-                  id="keywords-tt"
-                  tooltip="Key terms relating to the content of the document"
-                  heading="Keywords"
-                  text={page.keywords[0].name}
-                />
-                <DocumentInfo
-                  id="sectors-tt"
-                  tooltip="The broad areas of economic activity to which the content of the document relates, e.g. agriculture or transport. For more information, see our Methodology page"
-                  heading="Sectors"
-                  list={page.sectors}
-                />
-                <DocumentInfo
-                  id="instruments-tt"
-                  tooltip="The interventions or measures contained in the document, e.g. taxes or standards. For more information, see our Methodology page"
-                  heading="Instruments"
-                  list={page.instruments}
-                />
-                <div className="mt-8">
-                  <h4 className="text-base text-indigo-600 font-medium mb-4">
-                    Events
-                  </h4>
-                  {page.events.map((event, index) => (
-                    <Event
-                      event={event}
-                      key={`event${index}`}
-                      last={index === page.events.length - 1 ? true : false}
-                    />
-                  ))}
-                </div>
+                {page.topics.length > 0 && (
+                  <DocumentInfo
+                    id="topics-tt"
+                    tooltip="Broad areas of climate action contained in the document, e.g. mitigation or adaptation. For more information, see our Methodology page"
+                    heading="Topics"
+                    list={page.topics}
+                  />
+                )}
+
+                {page.languages.length > 0 && (
+                  <DocumentInfo
+                    heading="Language"
+                    text={page.languages[0].name}
+                  />
+                )}
+                {page.keywords.length > 0 && (
+                  <DocumentInfo
+                    id="keywords-tt"
+                    tooltip="Key terms relating to the content of the document"
+                    heading="Keywords"
+                    text={page.keywords[0].name}
+                  />
+                )}
+                {page.sectors.length > 0 && (
+                  <DocumentInfo
+                    id="sectors-tt"
+                    tooltip="The broad areas of economic activity to which the content of the document relates, e.g. agriculture or transport. For more information, see our Methodology page"
+                    heading="Sectors"
+                    list={page.sectors}
+                  />
+                )}
+                {page.instruments.length > 0 && (
+                  <DocumentInfo
+                    id="instruments-tt"
+                    tooltip="The interventions or measures contained in the document, e.g. taxes or standards. For more information, see our Methodology page"
+                    heading="Instruments"
+                    list={page.instruments}
+                  />
+                )}
+                {page.events.length > 0 && (
+                  <div className="mt-8">
+                    <h4 className="text-base text-indigo-600 font-medium mb-4">
+                      Events
+                    </h4>
+                    {page.events.map((event, index) => (
+                      <Event
+                        event={event}
+                        key={`event${index}`}
+                        last={index === page.events.length - 1 ? true : false}
+                      />
+                    ))}
+                  </div>
+                )}
               </section>
             </div>
           </div>


### PR DESCRIPTION
This adds logic which checks for a document 'content_type' that is 'application/pdf'. 

If it is a PDF, a PDF download icon/button will be visible on the document cover page.

If the document is a PDF and has passage matches, the 'X matches in  document' link will be visible in search results and clicking it will open the passage matches slideout panel, otherwise this link won't be displayed.

The document title will now always go to the document cover page when clicked.

Document cover page clickable icon has been removed from search results.

This PR depends on the search and document APIs to return a top level 'content_type' value.