### PR TITLE
text2embeddings runs with suitable efficiency

### DIFF
--- a/search-index/app/ml.py
+++ b/search-index/app/ml.py
@@ -59,7 +59,9 @@ class SBERTEncoder(SentenceEncoder):
         Returns:
             np.ndarray
         """
-        return self.encoder.encode(text_batch, batch_size=batch_size)
+        return self.encoder.encode(
+            text_batch, batch_size=batch_size, show_progress_bar=False
+        )
 
     @property
     def dimension(self) -> int:


### PR DESCRIPTION
When the number of md5sums increased by an order of magnitude, part of the text2embeddings process became painfully slow.
We were also getting a separate progress bar printed for each batch, as well as the main one, so I've disabled that.