### PR TITLE
Fix/stop unneeded search api calls

### DIFF
--- a/frontend/src/components/EmbeddedPDF.tsx
+++ b/frontend/src/components/EmbeddedPDF.tsx
@@ -32,8 +32,10 @@ const EmbeddedPDF = ({ document, passageIndex = null, setShowPDF = null }) => {
       previewFilePromise.then((adobeViewer) => {
         createAnnotationManager(adobeViewer);
         adobeViewer.getAPIs().then((apis) => {
+          apis.getZoomAPIs().zoomIn();
+          // Only jump to page if a passage is selected
+          if (!passageIndex) return;
           setTimeout(() => {
-            apis.getZoomAPIs().zoomIn();
             apis.gotoLocation(
               document.document_passage_matches[passageIndex].text_block_page
             );

--- a/frontend/src/components/PassageMatches.tsx
+++ b/frontend/src/components/PassageMatches.tsx
@@ -1,17 +1,15 @@
 import Loader from './Loader';
 
 const PassageMatches = ({ document, setShowPDF, setPassageIndex }) => {
-  const { data: doc } = document;
-
   return (
     <>
-      {!doc ? (
+      {!document ? (
         <div className="w-full flex justify-center h-96">
           <Loader />
         </div>
       ) : (
         <div className="px-6">
-          {doc.document_passage_matches.map((item, index) => (
+          {document.document_passage_matches.map((item, index) => (
             <div
               key={item.text_block_id}
               className="py-4 cursor-pointer"

--- a/frontend/src/constants/search.ts
+++ b/frontend/src/constants/search.ts
@@ -1,0 +1,5 @@
+export const emptySearchResults = {
+  hits: 0,
+  query_time_ms: 0,
+  documents: [],
+};

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -25,7 +25,7 @@ export default function useSearch(id, obj = initialSearchCriteria) {
     {
       enabled: obj.query_string.length > 0,
       refetchOnWindowFocus: false,
-      // refetchOnMount: false,
+      refetchOnMount: false,
       cacheTime: 1000 * 60 * 60 * 24,
     }
   );

--- a/frontend/src/hooks/useUpdateSearch.ts
+++ b/frontend/src/hooks/useUpdateSearch.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from 'react-query';
+
+export default function useUpdateSearch() {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (value: any) => {
+      return queryClient.setQueryData('searches', (old) => ({
+        ...old,
+        ...value,
+      }));
+    },
+
+    {
+      onError: (err) => {
+        console.log(err);
+      },
+    }
+  );
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,6 +12,8 @@ import AlphaLogo from '../components/logo/AlphaLogo';
 import ExactMatch from '../components/filters/ExactMatch';
 import LandingPageLinks from '../components/blocks/LandingPageLinks';
 import { initialSearchCriteria } from '../constants/searchCriteria';
+import { emptySearchResults } from '../constants/search';
+import useUpdateSearch from '../hooks/useUpdateSearch';
 import useNestedLookups from '../hooks/useNestedLookups';
 import useUpdateCountries from '../hooks/useUpdateCountries';
 import Tooltip from '../components/tooltip';
@@ -23,6 +25,7 @@ const IndexPage = () => {
   const { data: searchCriteria }: any = useSearchCriteria();
   const updateSearchCriteria = useUpdateSearchCriteria();
   const updateCountries = useUpdateCountries();
+  const updateSearch = useUpdateSearch();
 
   /* need this lookup to be able to reset filtered countries
   (sets suggest list that appears when typing a jurisdiction)
@@ -63,8 +66,12 @@ const IndexPage = () => {
       countries,
     });
   };
+  const clearSearch = () => {
+    updateSearch.mutate({ data: emptySearchResults });
+  };
   useEffect(() => {
     clearAllFilters();
+    clearSearch();
   }, []);
 
   return (

--- a/frontend/src/pages/pdf/[docId].tsx
+++ b/frontend/src/pages/pdf/[docId].tsx
@@ -62,7 +62,7 @@ const PDFView = () => {
             </TextLink>
           </div>
           <section className="mt-4 flex-1">
-            <div className="h-full container">
+            <div className="container pdf-container">
               <EmbeddedPDF document={document} />
             </div>
           </section>

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -67,7 +67,7 @@ const Search = () => {
     setShowSlideout(false);
   });
 
-  // lookups/filters
+  // get lookups/filters
   const documentTypesQuery: any = useLookups('document_types');
   const { data: { data: documentTypes = {} } = {} } = documentTypesQuery;
 
@@ -85,19 +85,21 @@ const Search = () => {
   const { data: { data: { level1: instruments = [] } = {} } = {} } =
     instrumentsQuery;
 
-  // search request
+  // search criteria and filters
   const {
     isFetching: isFetchingSearchCriteria,
     isSuccess: isSearchCriteriaSuccess,
     data: searchCriteria,
   }: any = useSearchCriteria();
-  const resultsQuery: any = useSearch('searches', searchCriteria);
 
+  // search results
+  const resultsQuery: any = useSearch('searches', searchCriteria);
   const {
-    data: { data: { documents } = [] } = [],
+    data: { data: { documents = [] } = [] } = [],
     data: { data: { hits } = 0 } = 0,
     isSuccess,
   } = resultsQuery;
+
   const document: any = useDocument();
   const { t, i18n, ready } = useTranslation(['searchStart', 'searchResults']);
   const placeholder = t("Search for something, e.g. 'carbon taxes'");
@@ -244,6 +246,7 @@ const Search = () => {
   }, [searchCriteria]);
 
   useEffect(() => {
+    // get selected category if one previously selected
     setCurrentCategoryIndex();
     // get page number if returning from another page
     // gets page number based on the last offset set in the search criteria
@@ -253,6 +256,10 @@ const Search = () => {
     // check for search query on initial load
     if (searchCriteria?.query_string.length) {
       setNoQuery(false);
+    }
+    // fetch search results if they are empty and search query exists
+    if (documents.length === 0 && searchCriteria?.query_string.length) {
+      resultsQuery.refetch();
     }
   }, []);
 

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -100,7 +100,7 @@ const Search = () => {
     isSuccess,
   } = resultsQuery;
 
-  const document: any = useDocument();
+  const { data: document }: any = ({} = useDocument());
   const { t, i18n, ready } = useTranslation(['searchStart', 'searchResults']);
   const placeholder = t("Search for something, e.g. 'carbon taxes'");
 
@@ -122,6 +122,7 @@ const Search = () => {
   const handlePageChange = (page: number) => {
     setPageNumber(page);
     setOffset((page - 1) * PER_PAGE);
+    setShowSlideout(false);
   };
 
   const handleFilterChange = (
@@ -185,13 +186,17 @@ const Search = () => {
     setShowFilters(!showFilters);
   };
   const handleDocumentClick = (e: any) => {
-    if (!e.target.dataset.docid) return;
     const id = e.target.dataset.docid;
-    if (!showSlideout) {
-      // only mutate if panel is being opened
-      updateDocument.mutate(id);
+    if (!id) return;
+
+    // keep panel open if clicking a different document
+    if (document?.document_id != id) {
+      setShowSlideout(true);
+    } else {
+      setShowSlideout(!showSlideout);
     }
-    setShowSlideout(!showSlideout);
+    updateDocument.mutate(id);
+
     setShowPDF(false);
   };
   const getCurrentSortChoice = () => {
@@ -278,155 +283,160 @@ const Search = () => {
           title={`Climate Policy Radar | ${t('Law and Policy Search')}`}
           heading={t('Law and Policy Search')}
         >
-          <Slideout
-            ref={slideoutRef}
-            show={showSlideout}
-            setShowSlideout={setShowSlideout}
-          >
-            <div className="flex flex-col h-full relative">
-              <DocumentSlideout
-                document={document.data}
-                setShowPDF={setShowPDF}
-                showPDF={showPDF}
-                setPassageIndex={setPassageIndex}
-              />
-              {showPDF ? (
-                <div className="mt-4 px-6 flex-1">
-                  <EmbeddedPDF
-                    document={document.data}
-                    passageIndex={passageIndex}
+          <div onClick={handleDocumentClick}>
+            <Slideout
+              ref={slideoutRef}
+              show={showSlideout}
+              setShowSlideout={setShowSlideout}
+            >
+              <div className="flex flex-col h-full relative">
+                <DocumentSlideout
+                  document={document}
+                  setShowPDF={setShowPDF}
+                  showPDF={showPDF}
+                  setPassageIndex={setPassageIndex}
+                />
+                {showPDF ? (
+                  <div className="mt-4 px-6 flex-1">
+                    <EmbeddedPDF
+                      document={document}
+                      passageIndex={passageIndex}
+                      setShowPDF={setShowPDF}
+                    />
+                  </div>
+                ) : (
+                  <PassageMatches
+                    document={document}
+                    setPassageIndex={setPassageIndex}
                     setShowPDF={setShowPDF}
                   />
-                </div>
-              ) : (
-                <PassageMatches
-                  document={document}
-                  setPassageIndex={setPassageIndex}
-                  setShowPDF={setShowPDF}
-                />
-              )}
-            </div>
-          </Slideout>
-          <section>
-            <div className="px-4 md:flex container border-b border-blue-200">
-              <div className="md:w-1/4 md:border-r border-blue-200 md:pr-8 flex-shrink-0">
-                <div className="flex flex items-center justify-center w-full">
-                  <FilterToggle toggle={toggleFilters} />
-                </div>
-
-                <div
-                  className={`${
-                    showFilters ? '' : 'hidden'
-                  } relative md:block md:mt-8 mb-12 md:mb-0`}
-                >
-                  <div className="md:hidden absolute right-0 top-0">
-                    <Close onClick={() => setShowFilters(false)} size="16" />
-                  </div>
-                  {geosQuery.isFetching ||
-                  sectorsQuery.isFetching ||
-                  documentTypesQuery.isFetching ||
-                  instrumentsQuery.isFetching ? (
-                    <p>Loading filters...</p>
-                  ) : (
-                    <SearchFilters
-                      handleFilterChange={handleFilterChange}
-                      searchCriteria={searchCriteria}
-                      handleYearChange={handleYearChange}
-                      handleRegionChange={handleRegionChange}
-                      handleClearSearch={handleClearSearch}
-                      regions={regions}
-                      filteredCountries={filteredCountries}
-                      sectors={sectors}
-                      documentTypes={documentTypes}
-                      instruments={structureData(instruments)}
-                    />
-                  )}
-                </div>
+                )}
               </div>
-              <div className="md:w-3/4">
-                <div className="md:py-8 md:pl-8">
-                  <p className="sm:hidden mt-4 mb-2">{placeholder}</p>
-                  <SearchForm
-                    placeholder={placeholder}
-                    handleSearchInput={handleSearchInput}
-                    input={searchCriteria.query_string}
-                  />
-                  <div className="flex justify-end mt-3">
-                    <ExactMatch
-                      checked={searchCriteria.exact_match}
-                      id="exact-match"
-                      handleSearchChange={handleSearchChange}
-                    />
-                    <div className="ml-1 -mt-1 text-sm">
-                      <Tooltip id="exact_match" tooltip={exactMatchTooltip} />
-                    </div>
-                  </div>
-                </div>
-                <div className="mt-4 relative z-10">
-                  <TabbedNav
-                    activeIndex={categoryIndex}
-                    items={documentCategories}
-                    handleTabClick={handleDocumentCategoryClick}
-                  />
-                  <div className="mt-4 md:absolute right-0 top-0 md:-mt-2 flex z-10">
-                    <Button
-                      color="light-hover-dark"
-                      thin={true}
-                      disabled={true}
-                      extraClasses="text-sm"
-                    >
-                      <div className="flex justify-center py-1">
-                        <DownloadIcon />
-                        <span>Download</span>
-                      </div>
-                    </Button>
-                    <div className="ml-1 mt-1">
-                      <Tooltip id="download-tt" tooltip={downloadCSVTooltip} />
-                    </div>
-                  </div>
-                </div>
-                <div className="mt-4 mb-8 flex justify-end">
-                  <div className="w-full md:w-1/2 lg:w-1/3 xl:w-1/4 flex items-center">
-                    <Sort
-                      defaultValue={getCurrentSortChoice()}
-                      updateSort={handleSortClick}
-                    />
-                    <div className="ml-1 -mt-1">
-                      <Tooltip id="sortby-tt" tooltip={sortByTooltip} />
-                    </div>
-                  </div>
-                </div>
-
-                <div className="md:pl-8 relative" onClick={handleDocumentClick}>
-                  {resultsQuery.isFetching ? (
-                    <div className="w-full flex justify-center h-96">
-                      <Loader />
-                    </div>
-                  ) : noQuery ? (
-                    <p className="font-bold text-red-500 h-96">
-                      Please enter some search terms.
-                    </p>
-                  ) : (
-                    <SearchResultList
-                      searchCriteria={searchCriteria}
-                      documents={documents}
-                    />
-                  )}
-                </div>
-              </div>
-            </div>
-          </section>
-          {pageCount > 1 && !noQuery && (
+            </Slideout>
             <section>
-              <div className="mb-12">
-                <Pagination
-                  pageNumber={pageNumber}
-                  pageCount={pageCount}
-                  onChange={handlePageChange}
-                />
+              <div className="px-4 md:flex container border-b border-blue-200">
+                <div className="md:w-1/4 md:border-r border-blue-200 md:pr-8 flex-shrink-0">
+                  <div className="flex flex items-center justify-center w-full">
+                    <FilterToggle toggle={toggleFilters} />
+                  </div>
+
+                  <div
+                    className={`${
+                      showFilters ? '' : 'hidden'
+                    } relative md:block md:mt-8 mb-12 md:mb-0`}
+                  >
+                    <div className="md:hidden absolute right-0 top-0">
+                      <Close onClick={() => setShowFilters(false)} size="16" />
+                    </div>
+                    {geosQuery.isFetching ||
+                    sectorsQuery.isFetching ||
+                    documentTypesQuery.isFetching ||
+                    instrumentsQuery.isFetching ? (
+                      <p>Loading filters...</p>
+                    ) : (
+                      <SearchFilters
+                        handleFilterChange={handleFilterChange}
+                        searchCriteria={searchCriteria}
+                        handleYearChange={handleYearChange}
+                        handleRegionChange={handleRegionChange}
+                        handleClearSearch={handleClearSearch}
+                        regions={regions}
+                        filteredCountries={filteredCountries}
+                        sectors={sectors}
+                        documentTypes={documentTypes}
+                        instruments={structureData(instruments)}
+                      />
+                    )}
+                  </div>
+                </div>
+                <div className="md:w-3/4">
+                  <div className="md:py-8 md:pl-8">
+                    <p className="sm:hidden mt-4 mb-2">{placeholder}</p>
+                    <SearchForm
+                      placeholder={placeholder}
+                      handleSearchInput={handleSearchInput}
+                      input={searchCriteria.query_string}
+                    />
+                    <div className="flex justify-end mt-3">
+                      <ExactMatch
+                        checked={searchCriteria.exact_match}
+                        id="exact-match"
+                        handleSearchChange={handleSearchChange}
+                      />
+                      <div className="ml-1 -mt-1 text-sm">
+                        <Tooltip id="exact_match" tooltip={exactMatchTooltip} />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-4 relative z-10">
+                    <TabbedNav
+                      activeIndex={categoryIndex}
+                      items={documentCategories}
+                      handleTabClick={handleDocumentCategoryClick}
+                    />
+                    <div className="mt-4 md:absolute right-0 top-0 md:-mt-2 flex z-10">
+                      <Button
+                        color="light-hover-dark"
+                        thin={true}
+                        disabled={true}
+                        extraClasses="text-sm"
+                      >
+                        <div className="flex justify-center py-1">
+                          <DownloadIcon />
+                          <span>Download</span>
+                        </div>
+                      </Button>
+                      <div className="ml-1 mt-1">
+                        <Tooltip
+                          id="download-tt"
+                          tooltip={downloadCSVTooltip}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-4 mb-8 flex justify-end">
+                    <div className="w-full md:w-1/2 lg:w-1/3 xl:w-1/4 flex items-center">
+                      <Sort
+                        defaultValue={getCurrentSortChoice()}
+                        updateSort={handleSortClick}
+                      />
+                      <div className="ml-1 -mt-1">
+                        <Tooltip id="sortby-tt" tooltip={sortByTooltip} />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="md:pl-8 relative">
+                    {resultsQuery.isFetching ? (
+                      <div className="w-full flex justify-center h-96">
+                        <Loader />
+                      </div>
+                    ) : noQuery ? (
+                      <p className="font-bold text-red-500 h-96">
+                        Please enter some search terms.
+                      </p>
+                    ) : (
+                      <SearchResultList
+                        searchCriteria={searchCriteria}
+                        documents={documents}
+                      />
+                    )}
+                  </div>
+                </div>
               </div>
             </section>
-          )}
+            {pageCount > 1 && !noQuery && (
+              <section>
+                <div className="mb-12">
+                  <Pagination
+                    pageNumber={pageNumber}
+                    pageCount={pageCount}
+                    onChange={handlePageChange}
+                  />
+                </div>
+              </section>
+            )}
+          </div>
         </Layout>
       )}
     </>

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -318,3 +318,10 @@ ul li.selected {
     }
   }
 }
+.pdf-container {
+  height: 440px;
+  margin-bottom: 16px;
+  @screen md {
+    height: 700px;
+  }
+}


### PR DESCRIPTION
This includes some improvements including:

- When visiting the search page, search api calls are only made when coming from the landing page or entering search terms. When returning from document cover page or other non-landing page, the previous search is retained and displayed without a new api call.
- Passage matches links still toggle the slideout panel unless switching between documents, then the panel updates with the new set of passage matches
- Full page PDF view expanded more in height, error that popped up when no passage selected is resolved.