### PR TITLE
Add list items and supprt for child lists

### DIFF
--- a/frontend/src/components/blocks/DocumentInfo.tsx
+++ b/frontend/src/components/blocks/DocumentInfo.tsx
@@ -1,23 +1,26 @@
 import Tooltip from "../tooltip";
 import List from "./List";
 
-interface ListType {
+type TListType = {
   name: string;
-  children?: string[];
-}
+  children?: TListChild[];
+};
 
-interface DoucmentInfoProps {
+type TListChild = {
+  parent: string;
+  name: string;
+};
+
+type TDoucmentInfoProps = {
   heading: string;
   text?: string;
-  list?: ListType[];
+  list?: TListType[];
   id?: string;
   tooltip?: string;
-}
+  bulleted?: boolean;
+};
 
-const DocumentInfo = ({ heading, text = "", list = [], id = "", tooltip = "" }: DoucmentInfoProps) => {
-  const renderList = (list: ListType[]) => {
-    return list.map((item, i) => [i > 0 && ", ", item.name]);
-  };
+const DocumentInfo = ({ heading, text = "", list = [], id = "", tooltip = "", bulleted = false }: TDoucmentInfoProps) => {
 
   return (
     <div className="mt-4">
@@ -29,7 +32,7 @@ const DocumentInfo = ({ heading, text = "", list = [], id = "", tooltip = "" }: 
           </div>
         )}
       </h4>
-      <p className="text-indigo-500">{list.length ? renderList(list) : text}</p>
+      {list.length ? <List list={list} bulleted={bulleted} /> : <p className="text-indigo-500">{text}</p>}
     </div>
   );
 };

--- a/frontend/src/components/blocks/List.tsx
+++ b/frontend/src/components/blocks/List.tsx
@@ -1,16 +1,18 @@
-const List = ({ list }) => {
+const List = ({ list, bulleted = false }) => {
+  const renderChildren = (list: any) => {
+    return <>: {list.map((item, i) => [i > 0 && ", ", item.name])}</>;
+  };
+
   return (
-    <ul className="text-indigo-500">
+    <ul className={`text-indigo-500 ${bulleted && "ml-4 list-disc list-outside mb-4"}`}>
       {list.map((item, index) => (
-        <li key={`listitem${index}`}>
-          {item.name}{' '}
-          {item?.children && (
-            <ul className="ml-4 list-disc list-outside mb-4">
-              {item.children.map((child, index) => (
-                <li key={`listchilditem${index}`}>{child.name}</li>
-              ))}{' '}
-            </ul>
-          )}
+        <li key={`listitem${index}`} className={!bulleted && "inline"}>
+          {
+            <>
+              {index > 0 && !bulleted && ", "} {item.name}
+            </>
+          }
+          {item?.children && renderChildren(item.children)}
         </li>
       ))}
     </ul>

--- a/frontend/src/pages/document/[docId].tsx
+++ b/frontend/src/pages/document/[docId].tsx
@@ -165,7 +165,7 @@ const DocumentCoverPage = () => {
 
                   {page.keywords.length > 0 && <DocumentInfo id="keywords-tt" heading="Keywords" list={page.keywords} />}
                   {page.sectors.length > 0 && <DocumentInfo id="sectors-tt" heading="Sectors" list={page.sectors} />}
-                  {page.instruments.length > 0 && <DocumentInfo id="instruments-tt" heading="Instruments" list={structureData(page.instruments)} />}
+                  {page.instruments.length > 0 && <DocumentInfo id="instruments-tt" heading="Instruments" list={structureData(page.instruments)} bulleted={true} />}
                   <div className="mt-8 border-t border-blue-100">
                     <h3 className="text-xl text-blue-700 mt-4">Source</h3>
                     <div className="flex items-end mt-4">


### PR DESCRIPTION
Fix an issue whereby document information list items were:
1 - not semantic HTML list elements
2 - not rendering child list items, where applicable