### PR TITLE
Feature/fro 63 document slide out

### DIFF
--- a/frontend/src/api/pdf.js
+++ b/frontend/src/api/pdf.js
@@ -29,6 +29,7 @@ class ViewSDKClient {
   }
 
   previewFile(doc, divId, viewerConfig) {
+    if(!doc) return;
     const config = {
       /* Pass your registered client id */
       clientId: process.env.NEXT_PUBLIC_ADOBE_API_KEY,

--- a/frontend/src/components/EmbeddedPDF.tsx
+++ b/frontend/src/components/EmbeddedPDF.tsx
@@ -1,10 +1,9 @@
-import Script from "next/script";
 import { useRef, useMemo, useEffect } from "react";
 import { v4 as uuidv4 } from "uuid";
-import ViewSDKClient from "../api/pdf";
-import Loader from "./Loader";
-import { padNumber } from "../utils/timedate";
+import Script from "next/script";
+import { padNumber } from "@utils/timedate";
 import usePDFPreview from "@hooks/usePDFPreview";
+import Loader from "./Loader";
 
 type TProps = {
   document: any;

--- a/frontend/src/components/headers/DocumentSlideout.tsx
+++ b/frontend/src/components/headers/DocumentSlideout.tsx
@@ -2,11 +2,10 @@ import Link from "next/link";
 import ToggleDocumentMenu from "../menus/ToggleDocumentMenu";
 import TextLink from "../nav/TextLink";
 
-const DocumentSlideout = ({ document, showPDF, setShowPDF, setPassageIndex }) => {
-
+const DocumentSlideout = ({ document, showPDF, setShowPDF }) => {
   if (!document) return null;
 
-  const year = document?.document_date.split('/')[2] ?? '';
+  const year = document?.document_date.split("/")[2] ?? "";
 
   return (
     <>
@@ -31,8 +30,16 @@ const DocumentSlideout = ({ document, showPDF, setShowPDF, setPassageIndex }) =>
                 Document {`match${document.document_passage_matches.length === 1 ? "" : "es"}`} ({document.document_passage_matches.length})
               </h3>
             </div>
-            <ToggleDocumentMenu setShowPDF={setShowPDF} showPDF={showPDF} document={document} setPassageIndex={setPassageIndex} />
+            <ToggleDocumentMenu document={document} />
           </div>
+          {showPDF && (
+            // TODO: translate below text
+            <div className="md-hidden">
+              <TextLink onClick={() => setShowPDF(false)}>
+                <span className="text-lg">&laquo;</span>Back to passage matches
+              </TextLink>
+            </div>
+          )}
         </>
       ) : null}
     </>

--- a/frontend/src/components/headers/DocumentSlideout.tsx
+++ b/frontend/src/components/headers/DocumentSlideout.tsx
@@ -34,7 +34,7 @@ const DocumentSlideout = ({ document, showPDF, setShowPDF }) => {
           </div>
           {showPDF && (
             // TODO: translate below text
-            <div className="md-hidden">
+            <div className="md:hidden">
               <TextLink onClick={() => setShowPDF(false)}>
                 <span className="text-lg">&laquo;</span>Back to passage matches
               </TextLink>

--- a/frontend/src/components/headers/DocumentSlideout.tsx
+++ b/frontend/src/components/headers/DocumentSlideout.tsx
@@ -33,12 +33,6 @@ const DocumentSlideout = ({ document, showPDF, setShowPDF, setPassageIndex }) =>
             </div>
             <ToggleDocumentMenu setShowPDF={setShowPDF} showPDF={showPDF} document={document} setPassageIndex={setPassageIndex} />
           </div>
-          {showPDF && (
-            // TODO: translate below text
-            <TextLink onClick={() => setShowPDF(false)}>
-              <span className="text-lg">&laquo;</span>Back to passage matches
-            </TextLink>
-          )}
         </>
       ) : null}
     </>

--- a/frontend/src/components/menus/DocumentMenu.tsx
+++ b/frontend/src/components/menus/DocumentMenu.tsx
@@ -1,43 +1,15 @@
-import DropdownMenuItem from './DropdownMenuItem';
-import DropdownMenuWrapper from './DropdownMenuWrapper';
+import DropdownMenuItem from "./DropdownMenuItem";
+import DropdownMenuWrapper from "./DropdownMenuWrapper";
 
-const DocumentMenu = ({
-  document,
-  setShowMenu,
-  setShowPDF,
-  showPDF,
-  setPassageIndex,
-}) => {
+const DocumentMenu = ({ document, setShowMenu }) => {
   return (
     <>
       {/* TODO: translate titles */}
       {document ? (
         <DropdownMenuWrapper setShowMenu={setShowMenu}>
-          {showPDF ? (
-            <DropdownMenuItem
-              first={true}
-              title="View passage matches"
-              onClick={() => setShowPDF(false)}
-            />
-          ) : (
-            <DropdownMenuItem
-              first={true}
-              title="View PDF"
-              onClick={() => {
-                setPassageIndex(null);
-                setShowPDF(true);
-              }}
-            />
-          )}
-          <DropdownMenuItem
-            href={`/pdf/${document.document_id}`}
-            title="View PDF in full window"
-          />
+          <DropdownMenuItem href={`/pdf/${document.document_id}`} title="View PDF in full window" />
           <DropdownMenuItem href={document.document_url} title="Download PDF" />
-          <DropdownMenuItem
-            href={`/document/${document.document_id}`}
-            title="View document details"
-          />
+          <DropdownMenuItem href={`/document/${document.document_id}`} title="View document details" />
         </DropdownMenuWrapper>
       ) : null}
     </>

--- a/frontend/src/components/menus/DocumentMenu.tsx
+++ b/frontend/src/components/menus/DocumentMenu.tsx
@@ -7,7 +7,7 @@ const DocumentMenu = ({ document, setShowMenu }) => {
       {/* TODO: translate titles */}
       {document ? (
         <DropdownMenuWrapper setShowMenu={setShowMenu}>
-          <DropdownMenuItem href={`/pdf/${document.document_id}`} title="View PDF in full window" />
+          <DropdownMenuItem href={`/pdf/${document.document_id}`} title="View PDF in full window" first />
           <DropdownMenuItem href={document.document_url} title="Download PDF" />
           <DropdownMenuItem href={`/document/${document.document_id}`} title="View document details" />
         </DropdownMenuWrapper>

--- a/frontend/src/components/menus/ToggleDocumentMenu.tsx
+++ b/frontend/src/components/menus/ToggleDocumentMenu.tsx
@@ -1,14 +1,9 @@
-import { useState, useRef } from 'react';
-import useOutsideAlerter from '../../hooks/useOutsideAlerter';
-import Kebab from '../buttons/Kebab';
-import DocumentMenu from './DocumentMenu';
+import { useState, useRef } from "react";
+import useOutsideAlerter from "../../hooks/useOutsideAlerter";
+import Kebab from "../buttons/Kebab";
+import DocumentMenu from "./DocumentMenu";
 
-const ToggleDocumentMenu = ({
-  document,
-  setShowPDF,
-  showPDF,
-  setPassageIndex,
-}) => {
+const ToggleDocumentMenu = ({ document }) => {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef(null);
   useOutsideAlerter(menuRef, () => setShowMenu(false));
@@ -19,18 +14,8 @@ const ToggleDocumentMenu = ({
   return (
     <div ref={menuRef} className="flex-shrink-0 mr-4">
       <Kebab onClick={toggleMenu} />
-      <div
-        className={`${
-          !showMenu ? 'hidden' : ''
-        } absolute top-0 right-0 mt-12 mr-4 z-50`}
-      >
-        <DocumentMenu
-          setShowMenu={setShowMenu}
-          setShowPDF={setShowPDF}
-          showPDF={showPDF}
-          document={document}
-          setPassageIndex={setPassageIndex}
-        />
+      <div className={`${!showMenu ? "hidden" : ""} absolute top-0 right-0 mt-12 mr-4 z-50`}>
+        <DocumentMenu setShowMenu={setShowMenu} document={document} />
       </div>
     </div>
   );

--- a/frontend/src/components/slideout/index.tsx
+++ b/frontend/src/components/slideout/index.tsx
@@ -1,5 +1,5 @@
-import Close from '../buttons/Close';
-import { forwardRef } from 'react';
+import Close from "../buttons/Close";
+import { forwardRef } from "react";
 
 interface SlideoutProps {
   children: JSX.Element | string;
@@ -7,27 +7,20 @@ interface SlideoutProps {
   setShowSlideout(value: boolean): void;
 }
 
-const Slideout = forwardRef(
-  (
-    { children, show, setShowSlideout }: SlideoutProps,
-    ref: React.RefObject<HTMLDivElement>
-  ) => {
-    return (
-      <div
-        ref={ref}
-        className={`${
-          show ? 'translate-x-0' : 'translate-x-[110%]'
-        } transition duration-500 origin-left transform bg-white pt-16 z-50 shadow-2xl shadow-black/40 h-screen fixed top-0 right-0 w-11/12 md:w-1/2 lg:w-5/12`}
-      >
-        <div className="absolute top-0 right-0 mt-4 mr-4">
-          <Close size="16" onClick={() => setShowSlideout(false)} />
-        </div>
-
-        <div className="h-full overflow-y-auto scrollbar-thumb-indigo-300 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full mr-2">
-          {children}
-        </div>
+const Slideout = forwardRef(({ children, show, setShowSlideout }: SlideoutProps, ref: React.RefObject<HTMLDivElement>) => {
+  return (
+    <div
+      ref={ref}
+      className={`${
+        show ? "translate-x-0" : "translate-x-[110%]"
+      } transition duration-500 origin-left transform bg-white pt-16 z-50 shadow-2xl shadow-black/40 h-screen fixed top-0 right-0 w-11/12`}
+    >
+      <div className="absolute top-0 right-0 mt-4 mr-4">
+        <Close size="16" onClick={() => setShowSlideout(false)} />
       </div>
-    );
-  }
-);
+
+      <div className="h-full overflow-y-auto scrollbar-thumb-indigo-300 scrollbar-thin scrollbar-track-white scrollbar-thumb-rounded-full mr-2">{children}</div>
+    </div>
+  );
+});
 export default Slideout;

--- a/frontend/src/constants/adobePDF.ts
+++ b/frontend/src/constants/adobePDF.ts
@@ -1,1 +1,0 @@
-export const PDF_API_KEY = 'dca9187b65294374a6367824df902fdf';

--- a/frontend/src/hooks/usePDFPreview.ts
+++ b/frontend/src/hooks/usePDFPreview.ts
@@ -1,0 +1,43 @@
+import ViewSDKClient from "@api/pdf";
+
+export default function usePDFPreview(document: any) {
+  const viewerConfig = {
+    showDownloadPDF: true,
+    showPrintPDF: true,
+    showLeftHandPanel: false,
+    enableAnnotationAPIs: true,
+    showAnnotationTools: true,
+  };
+
+  let viewSDKClient = null;
+  let embedApi = null;
+
+  const createPDFClient = (passage: number) => {
+    viewSDKClient = new ViewSDKClient();
+    viewSDKClient.ready().then(() => {
+      const previewFilePromise = viewSDKClient.previewFile(document, "pdf-div", viewerConfig);
+      previewFilePromise.then((adobeViewer) => {
+        // createAnnotationManager(adobeViewer);
+        adobeViewer.getAPIs().then((api) => {
+          embedApi = api;
+          passageIndexChangeHandler(passage);
+        });
+      });
+    });
+  };
+
+  const passageIndexChangeHandler = (passage: number) => {
+    if (!embedApi) {
+      return;
+    }
+    // Keep comment for reference - PDFs do not zoom uniformly, so I have removed for now
+    // embedApi.getZoomAPIs().setZoomLevel(1.5);
+    // Only jump to page if a passage is selected
+    if (passage === null) return;
+    setTimeout(() => {
+      embedApi.gotoLocation(document.document_passage_matches[passage].text_block_page);
+    }, 500);
+  };
+
+  return { createPDFClient, passageIndexChangeHandler };
+}

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -94,6 +94,11 @@ const Search = () => {
     setPageNumber(1);
   };
 
+  const resetSlideOut = (slideOut?: boolean) => {
+    setPassageIndex(null);
+    setShowSlideout(slideOut ?? !showSlideout);
+  }
+
   const handleRegionChange = (type, regionName) => {
     handleFilterChange(type, regionName);
     updateCountries.mutate({
@@ -170,9 +175,11 @@ const Search = () => {
 
     // keep panel open if clicking a different document
     if (document?.document_id != id) {
-      setShowSlideout(true);
+      // setShowSlideout(true);
+      resetSlideOut(true);
     } else {
-      setShowSlideout(!showSlideout);
+      // setShowSlideout(!showSlideout);
+      resetSlideOut();
     }
     updateDocument.mutate(id);
 
@@ -252,16 +259,24 @@ const Search = () => {
       ) : (
         <Layout title={`Climate Policy Radar | ${t("Law and Policy Search")}`} heading={t("Law and Policy Search")}>
           <div onClick={handleDocumentClick}>
-            <Slideout ref={slideoutRef} show={showSlideout} setShowSlideout={setShowSlideout}>
+            <Slideout ref={slideoutRef} show={showSlideout} setShowSlideout={resetSlideOut}>
               <div className="flex flex-col h-full relative">
                 <DocumentSlideout document={document} setShowPDF={setShowPDF} showPDF={showPDF} setPassageIndex={setPassageIndex} />
-                {showPDF ? (
+                {/* {showPDF ? (
                   <div className="mt-4 px-6 flex-1">
                     <EmbeddedPDF document={document} passageIndex={passageIndex} setShowPDF={setShowPDF} />
                   </div>
                 ) : (
                   <PassageMatches document={document} setPassageIndex={setPassageIndex} setShowPDF={setShowPDF} />
-                )}
+                )} */}
+                <div className="flex flex-1 h-0">
+                  <div className="w-1/3 overflow-y-scroll">
+                    <PassageMatches document={document} setPassageIndex={setPassageIndex} setShowPDF={setShowPDF} />
+                  </div>
+                  <div className="w-2/3 mt-4 px-6 flex-1">
+                    <EmbeddedPDF document={document} passageIndex={passageIndex} />
+                  </div>
+                </div>
               </div>
             </Slideout>
             {showSlideout && <div className="w-full h-full bg-overlayWhite fixed top-0 z-30" />}

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -90,6 +90,7 @@ const Search = () => {
   const documentCategories = ["All", "Executive", "Legislative", "Litigation"];
 
   const resetPaging = () => {
+    setShowPDF(false);
     setOffset(0);
     setPageNumber(1);
   };
@@ -183,7 +184,7 @@ const Search = () => {
     }
     updateDocument.mutate(id);
 
-    setShowPDF(false);
+    // setShowPDF(false);
   };
   const getCurrentSortChoice = () => {
     const field = searchCriteria.sort_field;
@@ -252,6 +253,8 @@ const Search = () => {
     }
   }, []);
 
+  console.log(showPDF);
+
   return (
     <>
       {isFetchingSearchCriteria || !ready || !user ? (
@@ -261,7 +264,7 @@ const Search = () => {
           <div onClick={handleDocumentClick}>
             <Slideout ref={slideoutRef} show={showSlideout} setShowSlideout={resetSlideOut}>
               <div className="flex flex-col h-full relative">
-                <DocumentSlideout document={document} setShowPDF={setShowPDF} showPDF={showPDF} setPassageIndex={setPassageIndex} />
+                <DocumentSlideout document={document} showPDF={showPDF} setShowPDF={setShowPDF} />
                 {/* {showPDF ? (
                   <div className="mt-4 px-6 flex-1">
                     <EmbeddedPDF document={document} passageIndex={passageIndex} setShowPDF={setShowPDF} />

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -90,15 +90,15 @@ const Search = () => {
   const documentCategories = ["All", "Executive", "Legislative", "Litigation"];
 
   const resetPaging = () => {
-    setShowPDF(false);
     setOffset(0);
     setPageNumber(1);
   };
 
   const resetSlideOut = (slideOut?: boolean) => {
+    setShowPDF(false);
     setPassageIndex(null);
     setShowSlideout(slideOut ?? !showSlideout);
-  }
+  };
 
   const handleRegionChange = (type, regionName) => {
     handleFilterChange(type, regionName);
@@ -253,8 +253,6 @@ const Search = () => {
     }
   }, []);
 
-  console.log(showPDF);
-
   return (
     <>
       {isFetchingSearchCriteria || !ready || !user ? (
@@ -272,11 +270,11 @@ const Search = () => {
                 ) : (
                   <PassageMatches document={document} setPassageIndex={setPassageIndex} setShowPDF={setShowPDF} />
                 )} */}
-                <div className="flex flex-1 h-0">
-                  <div className="w-1/3 overflow-y-scroll">
+                <div className="flex flex-col md:flex-row flex-1 h-0">
+                  <div className={`${showPDF ? "hidden" : "block"} md:block md:w-1/3 overflow-y-scroll`}>
                     <PassageMatches document={document} setPassageIndex={setPassageIndex} setShowPDF={setShowPDF} />
                   </div>
-                  <div className="w-2/3 mt-4 px-6 flex-1">
+                  <div className={`${showPDF ? "block" : "hidden"} md:block md:w-2/3 mt-4 px-6 flex-1`}>
                     <EmbeddedPDF document={document} passageIndex={passageIndex} />
                   </div>
                 </div>


### PR DESCRIPTION
Improve the UX and functionality of the document slide out and passage selection:
- PDF preview is displayed alongside passages 
- PDF scrolls to the relevant location in the document when a passage is selected
- On mobile devices the PDF and passages are split
- PDF is not longer re-rendered each interaction
- New reusable usePDFPreview hook 🪝 