### PR TITLE
Convert delay to a constant and speed it up

### DIFF
--- a/frontend/src/constants/document.ts
+++ b/frontend/src/constants/document.ts
@@ -1,1 +1,3 @@
 export const initialSummaryLength = 1400;
+
+export const PDF_SCROLL_DELAY = 100;

--- a/frontend/src/hooks/usePDFPreview.ts
+++ b/frontend/src/hooks/usePDFPreview.ts
@@ -1,4 +1,5 @@
 import ViewSDKClient from "@api/pdf";
+import { PDF_SCROLL_DELAY } from "@constants/document";
 
 export default function usePDFPreview(document: any) {
   const viewerConfig = {
@@ -36,7 +37,7 @@ export default function usePDFPreview(document: any) {
     if (passage === null) return;
     setTimeout(() => {
       embedApi.gotoLocation(document.document_passage_matches[passage].text_block_page);
-    }, 500);
+    }, PDF_SCROLL_DELAY);
   };
 
   return { createPDFClient, passageIndexChangeHandler };


### PR DESCRIPTION
Waiting time of 500ms is not necessary anymore due to the change that renders the PDF before the passage selection is interacted with and makes the app feel sluggish.

This is also now controlled by a constant.