### PR TITLE
remove test_pipeline and test_search_index from github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,28 +33,6 @@ jobs:
         run: cp frontend/e2e/.env.example frontend/e2e/.env
       - name: Run frontend tests
         run: make test_frontend
-  test_pipeline:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure docker-compose stack with .env.example
-        run: cp .env.example .env
-      - name: Build pipeline
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: make build_pipeline
-      - name: Test pipeline
-        run: make test_pipeline
-  test_search_index:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build docker-compose stack using .env.example
-        run: cp .env.example .env
-      - name: Build search_index
-        run: make build_search_index
-      - name: Test search_index
-        run: make test_search_index
   test_loader:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We moved the pipeline and search indexer to separate repos but i forgot to delete the github actions which trigger the make commands to build and test these in this repo.

At the moment these [complete in a few seconds](https://github.com/climatepolicyradar/navigator/actions/runs/2738658864) and sometimes confuse github into believing they never happened, causing it to wait infinitely for them to finish 