### PR TITLE
Fix BAK-1051: cleanup duplicate metadata table entries & associated bug

### DIFF
--- a/backend/app/api/api_v1/routers/documents.py
+++ b/backend/app/api/api_v1/routers/documents.py
@@ -1,7 +1,11 @@
 import logging
 import os
 from datetime import datetime
-from http.client import INTERNAL_SERVER_ERROR, UNPROCESSABLE_ENTITY
+from http.client import (
+    INTERNAL_SERVER_ERROR,
+    UNPROCESSABLE_ENTITY,
+    UNSUPPORTED_MEDIA_TYPE,
+)
 from pathlib import Path
 from typing import cast
 
@@ -316,7 +320,9 @@ def document_upload(
 
     # TODO: proper content-type validation
     if file_path.suffix.lower() not in CONTENT_TYPE_MAP:
-        raise HTTPException(415, "Unsupported Media Type: must be PDF or HTML.")
+        raise HTTPException(
+            UNSUPPORTED_MEDIA_TYPE, "Unsupported Media Type: must be PDF or HTML."
+        )
 
     try:
         s3_document = s3_client.upload_fileobj(

--- a/backend/app/core/service/loader.py
+++ b/backend/app/core/service/loader.py
@@ -26,7 +26,7 @@ from app.db.models import (
 )
 from app.db.schemas.document import DocumentCreateWithMetadata
 
-logger = logging.getLogger(__file__)
+_LOGGER = logging.getLogger(__file__)
 
 
 class UnknownMetadataError(Exception):
@@ -98,7 +98,7 @@ def persist_document_and_metadata(
 
         return db_document
     except Exception as e:
-        logger.error(
+        _LOGGER.error(
             f"Error saving document {document_with_metadata.document}", exc_info=e
         )
         if isinstance(e, IntegrityError):
@@ -107,7 +107,7 @@ def persist_document_and_metadata(
 
 
 def write_metadata(
-    db,
+    db: Session,
     db_document: Document,
     document_with_metadata: DocumentCreateWithMetadata,
 ):
@@ -136,17 +136,16 @@ def write_metadata(
     # sectors
     for sector in document_with_metadata.sectors:
         # A sector should already exist, so fail if we cannot find it
-        existing_sector = (
-            db.query(Sector)
+        existing_sector_id = (
+            db.query(Sector.id)
             .filter(Sector.name == sector.name)
             .filter(Sector.source_id == db_document.source_id)
-        ).first()
-        if existing_sector is None:
+        ).scalar()
+        if existing_sector_id is None:
             raise UnknownSectorError(sector.name)
 
-        sector_id = existing_sector.id  # type: ignore
         doc_sector = DocumentSector(
-            sector_id=sector_id,
+            sector_id=existing_sector_id,
             document_id=db_document.id,
         )
         db.add(doc_sector)
@@ -154,17 +153,16 @@ def write_metadata(
     # instruments
     for instrument in document_with_metadata.instruments:
         # An instrument should already exist, so fail if we cannot find it
-        existing_instrument = (
-            db.query(Instrument)
+        existing_instrument_id = (
+            db.query(Instrument.id)
             .filter(Instrument.name == instrument.name)
             .filter(Instrument.source_id == db_document.source_id)
-        ).first()
-        if existing_instrument is None:
+        ).scalar()
+        if existing_instrument_id is None:
             raise UnknownInstrumentError(instrument.name)
 
-        instrument_id = existing_instrument.id  # type: ignore
         doc_instrument = DocumentInstrument(
-            instrument_id=instrument_id,
+            instrument_id=existing_instrument_id,
             document_id=db_document.id,
         )
         db.add(doc_instrument)
@@ -172,13 +170,14 @@ def write_metadata(
     # hazards
     for hazard in document_with_metadata.hazards:
         # A hazard should already exist, so fail if we cannot find it
-        existing_hazard = (db.query(Hazard).filter(Hazard.name == hazard.name)).first()
-        if existing_hazard is None:
+        existing_hazard_id = (
+            db.query(Hazard.id).filter(Hazard.name == hazard.name)
+        ).scalar()
+        if existing_hazard_id is None:
             raise UnknownHazardError(hazard.name)
 
-        hazard_id = existing_hazard.id  # type: ignore
         doc_hazard = DocumentHazard(
-            hazard_id=hazard_id,
+            hazard_id=existing_hazard_id,
             document_id=db_document.id,
         )
         db.add(doc_hazard)
@@ -186,15 +185,14 @@ def write_metadata(
     # responses
     for response in document_with_metadata.responses:
         # A response should already exist, so fail if we cannot find it
-        existing_response = (
-            db.query(Response).filter(Response.name == response.name)
-        ).first()
-        if existing_response is None:
+        existing_response_id = (
+            db.query(Response.id).filter(Response.name == response.name)
+        ).scalar()
+        if existing_response_id is None:
             raise UnknownResponseError(response.name)
 
-        response_id = existing_response.id  # type: ignore
         doc_response = DocumentResponse(
-            response_id=response_id,
+            response_id=existing_response_id,
             document_id=db_document.id,
         )
         db.add(doc_response)
@@ -202,15 +200,14 @@ def write_metadata(
     # frameworks
     for framework in document_with_metadata.frameworks:
         # A framework should already exist, so fail if we cannot find it
-        existing_framework = (
-            db.query(Framework).filter(Framework.name == framework.name)
-        ).first()
-        if existing_framework is None:
+        existing_framework_id = (
+            db.query(Framework.id).filter(Framework.name == framework.name)
+        ).scalar()
+        if existing_framework_id is None:
             raise UnknownFrameworkError(framework.name)
 
-        framework_id = existing_framework.id  # type: ignore
         doc_framework = DocumentFramework(
-            framework_id=framework_id,
+            framework_id=existing_framework_id,
             document_id=db_document.id,
         )
         db.add(doc_framework)
@@ -218,15 +215,14 @@ def write_metadata(
     # keywords
     for keyword in document_with_metadata.keywords:
         # A keyword should already exist, so fail if we cannot find it
-        existing_keyword = (
-            db.query(Keyword).filter(Keyword.name == keyword.name)
-        ).first()
-        if existing_keyword is None:
+        existing_keyword_id = (
+            db.query(Keyword.id).filter(Keyword.name == keyword.name)
+        ).scalar()
+        if existing_keyword_id is None:
             raise UnknownKeywordError(keyword.name)
 
-        keyword_id = existing_keyword.id  # type: ignore
         doc_keyword = DocumentKeyword(
-            keyword_id=keyword_id,
+            keyword_id=existing_keyword_id,
             document_id=db_document.id,
         )
         db.add(doc_keyword)

--- a/backend/app/core/service/loader.py
+++ b/backend/app/core/service/loader.py
@@ -3,7 +3,6 @@ import logging
 from fastapi import (
     HTTPException,
 )
-from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -28,6 +27,49 @@ from app.db.models import (
 from app.db.schemas.document import DocumentCreateWithMetadata
 
 logger = logging.getLogger(__file__)
+
+
+class UnknownMetadataError(Exception):
+    """Base class for metadata lookup errors."""
+
+    pass
+
+
+class UnknownSectorError(UnknownMetadataError):
+    """Error raised when a sector cannot be found in the database."""
+
+    def __init__(self, sector: str) -> None:
+        super().__init__(f"The sector '{sector}' could not be found in the database")
+
+
+class UnknownInstrumentError(UnknownMetadataError):
+    """Error raised when an instrument cannot be found in the database."""
+
+    def __init__(self, instrument: str) -> None:
+        super().__init__(
+            f"The instrument '{instrument}' could not be found in the database"
+        )
+
+
+class UnknownHazardError(UnknownMetadataError):
+    """Error raised when a hazard cannot be found in the database."""
+
+    def __init__(self, hazard: str) -> None:
+        super().__init__(f"The hazard '{hazard}' could not be found in the database")
+
+
+class UnknownResponseError(UnknownMetadataError):
+    """Error raised when a response cannot be found in the database."""
+
+    def __init__(self, response: str) -> None:
+        super().__init__(f"The  '{response}' could not be found in the database")
+
+
+class UnknownKeywordError(UnknownMetadataError):
+    """Error raised when a keyword cannot be found in the database."""
+
+    def __init__(self, keyword: str) -> None:
+        super().__init__(f"The  '{keyword}' could not be found in the database")
 
 
 def persist_document_and_metadata(
@@ -57,11 +99,11 @@ def write_metadata(
 ):
     # doc language
     for language_id in document_with_metadata.language_ids:
-        db_doc_lang = DocumentLanguage(
+        doc_language = DocumentLanguage(
             language_id=language_id,
             document_id=db_document.id,
         )
-        db.add(db_doc_lang)
+        db.add(doc_language)
 
     # events
     for event in document_with_metadata.events:
@@ -73,147 +115,104 @@ def write_metadata(
         )
         db.add(db_event)
 
-    # sectors
-    for meta in document_with_metadata.sectors:
-        insert_stmt = insert(Sector).values(
-            # parent_id=TODO,
-            name=meta.name,
-            description=meta.description,
-            source_id=db_document.source_id,
-        )
-        do_nothing_stmt = insert_stmt.on_conflict_do_nothing()
-        return_value = db.execute(do_nothing_stmt)
-        if return_value and return_value.inserted_primary_key:
-            meta_id = return_value.inserted_primary_key[0]
-        else:
-            # This is guaranteed to exist
-            existing_sector = (
-                db.query(Sector)
-                .filter(Sector.name == meta.name)
-                .filter(Sector.source_id == db_document.source_id)
-            ).first()
-            meta_id = existing_sector.id  # type: ignore
+    # TODO: are source IDs really necessary on metadata? Perhaps we really do
+    #       want to keep metadata limited to values from the same source as the
+    #       document, but we should validate this assumption.
 
-        db_bridge = DocumentSector(
-            sector_id=meta_id,
+    # sectors
+    for sector in document_with_metadata.sectors:
+        # A sector should already exist, so fail if we cannot find it
+        existing_sector = (
+            db.query(Sector)
+            .filter(Sector.name == sector.name)
+            .filter(Sector.source_id == db_document.source_id)
+        ).first()
+        if existing_sector is None:
+            raise UnknownSectorError(sector.name)
+
+        sector_id = existing_sector.id  # type: ignore
+        doc_sector = DocumentSector(
+            sector_id=sector_id,
             document_id=db_document.id,
         )
-        db.add(db_bridge)
+        db.add(doc_sector)
 
     # instruments
-    for meta in document_with_metadata.instruments:
-        insert_stmt = insert(Instrument).values(
-            # parent_id=TODO,
-            name=meta.name,
-            description=meta.description,
-            source_id=db_document.source_id,
-        )
-        do_nothing_stmt = insert_stmt.on_conflict_do_nothing()
-        return_value = db.execute(do_nothing_stmt)
-        if return_value and return_value.inserted_primary_key:
-            meta_id = return_value.inserted_primary_key[0]
-        else:
-            # This is guaranteed to exist
-            existing_instrument = (
-                db.query(Instrument)
-                .filter(Instrument.name == meta.name)
-                .filter(Instrument.source_id == db_document.source_id)
-            ).first()
-            meta_id = existing_instrument.id  # type: ignore
+    for instrument in document_with_metadata.instruments:
+        # An instrument should already exist, so fail if we cannot find it
+        existing_instrument = (
+            db.query(Instrument)
+            .filter(Instrument.name == instrument.name)
+            .filter(Instrument.source_id == db_document.source_id)
+        ).first()
+        if existing_instrument is None:
+            raise UnknownInstrumentError(instrument.name)
 
-        db_bridge = DocumentInstrument(
-            instrument_id=meta_id,
+        instrument_id = existing_instrument.id  # type: ignore
+        doc_instrument = DocumentInstrument(
+            instrument_id=instrument_id,
             document_id=db_document.id,
         )
-        db.add(db_bridge)
+        db.add(doc_instrument)
 
     # hazards
-    for meta in document_with_metadata.hazards:
-        insert_stmt = insert(Hazard).values(
-            name=meta.name,
-            description=meta.description,
-        )
-        do_nothing_stmt = insert_stmt.on_conflict_do_nothing()
-        return_value = db.execute(do_nothing_stmt)
-        if return_value and return_value.inserted_primary_key:
-            meta_id = return_value.inserted_primary_key[0]
-        else:
-            # This is guaranteed to exist
-            existing_hazard = (
-                db.query(Hazard).filter(Hazard.name == meta.name)
-            ).first()
-            meta_id = existing_hazard.id  # type: ignore
+    for hazard in document_with_metadata.hazards:
+        # A hazard should already exist, so fail if we cannot find it
+        existing_hazard = (db.query(Hazard).filter(Hazard.name == hazard.name)).first()
+        if existing_hazard is None:
+            raise UnknownHazardError(hazard.name)
 
-        db_bridge = DocumentHazard(
-            hazard_id=meta_id,
+        hazard_id = existing_hazard.id  # type: ignore
+        doc_hazard = DocumentHazard(
+            hazard_id=hazard_id,
             document_id=db_document.id,
         )
-        db.add(db_bridge)
+        db.add(doc_hazard)
 
     # responses
-    for meta in document_with_metadata.responses:
-        insert_stmt = insert(Response).values(
-            name=meta.name,
-            description=meta.description,
-        )
-        do_nothing_stmt = insert_stmt.on_conflict_do_nothing()
-        return_value = db.execute(do_nothing_stmt)
-        if return_value and return_value.inserted_primary_key:
-            meta_id = return_value.inserted_primary_key[0]
-        else:
-            # This is guaranteed to exist
-            existing_sector = (
-                db.query(Response).filter(Response.name == meta.name)
-            ).first()
-            meta_id = existing_sector.id  # type: ignore
+    for response in document_with_metadata.responses:
+        # A response should already exist, so fail if we cannot find it
+        existing_response = (
+            db.query(Response).filter(Response.name == response.name)
+        ).first()
+        if existing_response is None:
+            raise UnknownResponseError(response.name)
 
-        db_bridge = DocumentResponse(
-            response_id=meta_id,
+        response_id = existing_response.id  # type: ignore
+        doc_response = DocumentResponse(
+            response_id=response_id,
             document_id=db_document.id,
         )
-        db.add(db_bridge)
+        db.add(doc_response)
 
     # frameworks
-    for meta in document_with_metadata.frameworks:
-        insert_stmt = insert(Framework).values(
-            name=meta.name,
-            description=meta.description,
-        )
-        do_nothing_stmt = insert_stmt.on_conflict_do_nothing()
-        return_value = db.execute(do_nothing_stmt)
-        if return_value and return_value.inserted_primary_key:
-            meta_id = return_value.inserted_primary_key[0]
-        else:
-            # This is guaranteed to exist
-            existing_framework = (
-                db.query(Framework).filter(Framework.name == meta.name)
-            ).first()
-            meta_id = existing_framework.id  # type: ignore
+    for framework in document_with_metadata.frameworks:
+        # A framework should already exist, so fail if we cannot find it
+        existing_framework = (
+            db.query(Framework).filter(Framework.name == framework.name)
+        ).first()
+        if existing_framework is None:
+            raise UnknownResponseError(framework.name)
 
-        db_bridge = DocumentFramework(
-            framework_id=meta_id,
+        framework_id = existing_framework.id  # type: ignore
+        doc_framework = DocumentFramework(
+            framework_id=framework_id,
             document_id=db_document.id,
         )
-        db.add(db_bridge)
+        db.add(doc_framework)
 
-    for meta in document_with_metadata.keywords:
-        insert_stmt = insert(Keyword).values(
-            name=meta.name,
-            description=meta.description,
-        )
-        do_nothing_stmt = insert_stmt.on_conflict_do_nothing()
-        return_value = db.execute(do_nothing_stmt)
-        if return_value and return_value.inserted_primary_key:
-            meta_id = return_value.inserted_primary_key[0]
-        else:
-            # This is guaranteed to exist
-            existing_keyword = (
-                db.query(Keyword).filter(Keyword.name == meta.name)
-            ).first()
-            meta_id = existing_keyword.id  # type: ignore
+    # keywords
+    for keyword in document_with_metadata.keywords:
+        # A keyword should already exist, so fail if we cannot find it
+        existing_keyword = (
+            db.query(Keyword).filter(Keyword.name == keyword.name)
+        ).first()
+        if existing_keyword is None:
+            raise UnknownKeywordError(keyword.name)
 
-        db_bridge = DocumentKeyword(
-            keyword_id=meta_id,
+        keyword_id = existing_keyword.id  # type: ignore
+        doc_keyword = DocumentKeyword(
+            keyword_id=keyword_id,
             document_id=db_document.id,
         )
-        db.add(db_bridge)
+        db.add(doc_keyword)

--- a/backend/app/db/crud/document.py
+++ b/backend/app/db/crud/document.py
@@ -1,13 +1,12 @@
 from fastapi import HTTPException
 from sqlalchemy import and_, exists
-from sqlalchemy.orm import Session
 
 from app.db.models import Document
 from app.db.schemas.document import DocumentCreate
 
 
 def create_document(
-    db: Session,
+    db,
     document: DocumentCreate,
     creator_id: int,
 ) -> Document:
@@ -27,16 +26,14 @@ def create_document(
     )
 
     db.add(db_document)
-    # TODO don't call commit here. Perhaps in a middleware somewhere before the response is returned
-    # Removing commit here will ensure: roll back the doc if there's a subsequent error persisting metadata.
-    db.commit()
+    db.flush()
     db.refresh(db_document)
 
     return db_document
 
 
 def is_document_exists(
-    db: Session,
+    db,
     document: DocumentCreate,
 ) -> bool:
     # Returns a doc by its unique constraint.
@@ -53,7 +50,7 @@ def is_document_exists(
     ).scalar()
 
 
-def get_document(db: Session, document_id: int) -> Document:
+def get_document(db, document_id: int) -> Document:
     document = db.query(Document).filter(Document.id == document_id).first()
     if not document:
         raise HTTPException(

--- a/backend/scripts/cleanup_lookups.py
+++ b/backend/scripts/cleanup_lookups.py
@@ -28,32 +28,34 @@ def cleanup_keyword_duplicates(db: SessionLocal) -> None:  # type: ignore
     for document_keyword in db.query(DocumentKeyword).all():
         if int(document_keyword.keyword_id) not in desired_keyword_ids:
             # Get the name of the linked keyword & update to the desired value
-            existing_keyword = (
-                db.query(Keyword).filter(id=document_keyword.keyword_id).first()
-            )
+            existing_keyword = db.query(Keyword).get(document_keyword.keyword_id)
             required_id = clean_keyword_lookup_table[existing_keyword.name]
             document_keyword.keyword_id = required_id
 
+    db.flush()
+
     for keyword in db.query(Keyword).all():
         if keyword.id not in desired_keyword_ids:
-            keyword.delete()
+            db.delete(keyword)
 
 
 def cleanup_instrument_duplicates(db: SessionLocal) -> None:  # type: ignore
     clean_instrument_lookup_table = get_model_values(db, Instrument)
     desired_instrument_ids = list(clean_instrument_lookup_table.values())
-    for row in db.query(DocumentInstrument).all():
-        if int(row.instrument_id) not in desired_instrument_ids:
+    for document_instrument in db.query(DocumentInstrument).all():
+        if int(document_instrument.instrument_id) not in desired_instrument_ids:
             # Get the name of the linked instrument & update to the desired value
-            existing_instrument = (
-                db.query(Instrument).filter(id=row.instrument_id).first()
+            existing_instrument = db.query(Instrument).get(
+                document_instrument.instrument_id
             )
             required_id = clean_instrument_lookup_table[existing_instrument.name]
-            row.keyword_id = required_id
+            document_instrument.instrument_id = required_id
 
-    for instrument in db.query(Keyword).all():
+    db.flush()
+
+    for instrument in db.query(Instrument).all():
         if instrument.id not in desired_instrument_ids:
-            instrument.delete()
+            db.delete(instrument)
 
 
 if __name__ == "__main__":
@@ -62,8 +64,10 @@ if __name__ == "__main__":
 
     print("Cleaning Keywords...")
     cleanup_keyword_duplicates(db)
+    db.commit()
+
     print("Cleaning Instruments...")
     cleanup_instrument_duplicates(db)
-
     db.commit()
+
     print("Done cleaning duplicated lookups in database")

--- a/backend/scripts/cleanup_lookups.py
+++ b/backend/scripts/cleanup_lookups.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+from typing import Dict, Mapping
+
+from app.db.models import DocumentInstrument, DocumentKeyword, Instrument, Keyword
+from app.db.session import Base, SessionLocal
+
+
+LookupID = Mapping[str, int]
+
+
+def get_model_values(db: SessionLocal, table: Base) -> LookupID:  # type: ignore
+    id_lookup: Dict[str, int] = {}
+
+    for row in db.query(table).all():
+        should_update_lookup = row.name not in id_lookup or id_lookup[row.name] > int(
+            row.id
+        )
+        if should_update_lookup:
+            id_lookup[row.name] = int(row.id)
+
+    return id_lookup
+
+
+def cleanup_keyword_duplicates(db: SessionLocal) -> None:  # type: ignore
+    clean_keyword_lookup_table = get_model_values(db, Keyword)
+    desired_keyword_ids = list(clean_keyword_lookup_table.values())
+    for document_keyword in db.query(DocumentKeyword).all():
+        if int(document_keyword.keyword_id) not in desired_keyword_ids:
+            # Get the name of the linked keyword & update to the desired value
+            existing_keyword = (
+                db.query(Keyword).filter(id=document_keyword.keyword_id).first()
+            )
+            required_id = clean_keyword_lookup_table[existing_keyword.name]
+            document_keyword.keyword_id = required_id
+
+    for keyword in db.query(Keyword).all():
+        if keyword.id not in desired_keyword_ids:
+            keyword.delete()
+
+
+def cleanup_instrument_duplicates(db: SessionLocal) -> None:  # type: ignore
+    clean_instrument_lookup_table = get_model_values(db, Instrument)
+    desired_instrument_ids = list(clean_instrument_lookup_table.values())
+    for row in db.query(DocumentInstrument).all():
+        if int(row.instrument_id) not in desired_instrument_ids:
+            # Get the name of the linked instrument & update to the desired value
+            existing_instrument = (
+                db.query(Instrument).filter(id=row.instrument_id).first()
+            )
+            required_id = clean_instrument_lookup_table[existing_instrument.name]
+            row.keyword_id = required_id
+
+    for instrument in db.query(Keyword).all():
+        if instrument.id not in desired_instrument_ids:
+            instrument.delete()
+
+
+if __name__ == "__main__":
+    print("Cleaning duplicated lookups in database...")
+    db = SessionLocal()
+
+    print("Cleaning Keywords...")
+    cleanup_keyword_duplicates(db)
+    print("Cleaning Instruments...")
+    cleanup_instrument_duplicates(db)
+
+    db.commit()
+    print("Done cleaning duplicated lookups in database")

--- a/backend/tests/routes/test_documents.py
+++ b/backend/tests/routes/test_documents.py
@@ -68,6 +68,25 @@ def test_post_documents(client, superuser_token_headers, test_db):
     test_db.add(DocumentType(name="just my type", description="sigh"))
     test_db.add(Language(language_code="afr"))
     test_db.add(Category(name="a category", description="a category description"))
+    test_db.add(Hazard(name="some hazard", description="Imported by CPR loader"))
+    test_db.add(Response(name="Mitigation", description="Imported by CPR loader"))
+    test_db.add(Framework(name="some framework", description="Imported by CPR loader"))
+    test_db.add(Keyword(name="some keyword", description="Imported by CPR loader"))
+    test_db.commit()
+
+    test_db.add(
+        Sector(name="Energy", description="Imported by CPR loader", source_id=1)
+    )
+    test_db.add(
+        Instrument(
+            name="some instrument", description="Imported by CPR loader", source_id=1
+        )
+    )
+    test_db.add(
+        Instrument(
+            name="another instrument", description="Imported by CPR loader", source_id=1
+        )
+    )
     test_db.commit()
 
     payload = {
@@ -136,15 +155,97 @@ def test_post_documents(client, superuser_token_headers, test_db):
     event = test_db.query(Event).first()
     assert event.name == "Publication"
     assert event.created_ts == datetime(2008, 12, 25, 0, 0, tzinfo=timezone.utc)
-    assert test_db.query(Sector).first().name == "Energy"
-    assert test_db.query(Response).first().name == "Mitigation"
-    assert test_db.query(Hazard).first().name == "some hazard"
-    assert test_db.query(Framework).first().name == "some framework"
-    assert test_db.query(Keyword).first().name == "some keyword"
-    instruments = test_db.query(Instrument).all()
-    assert instruments[0].name == "some instrument"
-    assert instruments[1].name == "another instrument"
     assert test_db.query(DocumentLanguage).first().document_id == 1
+
+
+def test_post_documents_fail(client, superuser_token_headers, test_db):
+
+    # ensure meta
+    test_db.add(Source(name="may it be with you"))
+    test_db.add(Geography(display_value="not my favourite subject"))
+    test_db.add(DocumentType(name="just my type", description="sigh"))
+    test_db.add(Language(language_code="afr"))
+    test_db.add(Category(name="a category", description="a category description"))
+    test_db.add(Hazard(name="some other hazard", description="Imported by CPR loader"))
+    test_db.add(Response(name="Mitigation", description="Imported by CPR loader"))
+    test_db.add(
+        Framework(name="some other framework", description="Imported by CPR loader")
+    )
+    test_db.add(Keyword(name="some keyword", description="Imported by CPR loader"))
+    test_db.commit()
+
+    test_db.add(
+        Sector(name="Energy", description="Imported by CPR loader", source_id=1)
+    )
+    test_db.add(
+        Instrument(
+            name="some instrument", description="Imported by CPR loader", source_id=1
+        )
+    )
+    test_db.add(
+        Instrument(
+            name="another instrument", description="Imported by CPR loader", source_id=1
+        )
+    )
+    test_db.commit()
+
+    payload = {
+        "document": {
+            "loaded_ts": "2022-04-26T15:33:40.470413+00:00",
+            "publication_ts": "2000-01-01T00:00:00.000000+00:00",
+            "name": "Energy Sector Strategy 1387-1391 (2007/8-2012/3)",
+            "description": "the document description",
+            "source_url": "https://climate-laws.org/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBcG9IIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--be6991246abda10bef5edc0a4d196b73ce1b1a26/f",
+            "url": "https://cpr-document-queue.s3.eu-west-2.amazonaws.com/AFG/2008-12-25/AFG-2008-12-25-Energy Sector Strategy 1387-1391 (2007/8-2012/3)-1.pdf",
+            "md5_sum": "the md5 sum",
+            "type_id": 1,
+            "geography_id": 1,
+            "source_id": 1,
+            "category_id": 1,
+        },
+        "language_ids": [1],
+        "source_id": 1,
+        "events": [
+            {
+                "name": "Publication",
+                "description": "The publication date",
+                "created_ts": "2008-12-25T00:00:00+00:00",
+            }
+        ],
+        "sectors": [
+            {
+                "name": "Energy",
+                "description": "Imported by CPR loader",
+                "source_id": 1,
+            }
+        ],
+        "instruments": [
+            {
+                "name": "some instrument",
+                "description": "Imported by CPR loader",
+                "source_id": 1,
+            },
+            {
+                "name": "another instrument",
+                "description": "Imported by CPR loader",
+                "source_id": 1,
+            },
+        ],
+        "frameworks": [
+            {"name": "some framework", "description": "Imported by CPR loader"}
+        ],
+        "responses": [{"name": "Mitigation", "description": "Imported by CPR loader"}],
+        "hazards": [{"name": "some hazard", "description": "Imported by CPR loader"}],
+        "keywords": [{"name": "some keyword", "description": "Imported by CPR loader"}],
+    }
+
+    response = client.post(
+        "/api/v1/documents", headers=superuser_token_headers, json=payload
+    )
+
+    assert response.status_code == 422
+    assert len(list(test_db.query(Document).all())) == 0
+    assert test_db.query(Event).first() is None
 
 
 def test_document_detail(
@@ -168,6 +269,57 @@ def test_document_detail(
     test_db.add(DocumentType(name="just my type", description="sigh"))
     test_db.add(Language(language_code="afr", name="AFRAFR"))
     test_db.add(Category(name="a category", description="a category description"))
+    test_db.add(Keyword(name="some keyword", description="Imported by CPR loader"))
+    test_db.add(
+        Keyword(name="some other keyword", description="Imported by CPR loader")
+    )
+    test_db.add(Hazard(name="some hazard", description="Imported by CPR loader"))
+    test_db.add(
+        Hazard(name="some other hazard 1", description="Imported by CPR loader")
+    )
+    test_db.add(
+        Hazard(name="some other hazard 2", description="Imported by CPR loader")
+    )
+    test_db.add(Response(name="Mitigation", description="Imported by CPR loader"))
+    test_db.add(Framework(name="some framework", description="Imported by CPR loader"))
+    test_db.add(
+        Framework(name="some other framework 1", description="Imported by CPR loader")
+    )
+    test_db.add(
+        Framework(name="some other framework 2", description="Imported by CPR loader")
+    )
+    test_db.commit()
+
+    test_db.add(
+        Instrument(
+            name="some instrument", description="Imported by CPR loader", source_id=1
+        )
+    )
+    test_db.add(
+        Instrument(
+            name="some other instrument",
+            description="Imported by CPR loader",
+            source_id=1,
+        )
+    )
+    test_db.add(
+        Instrument(
+            name="another instrument", description="Imported by CPR loader", source_id=1
+        )
+    )
+    test_db.add(
+        Instrument(
+            name="another other instrument",
+            description="Imported by CPR loader",
+            source_id=1,
+        )
+    )
+    test_db.add(
+        Sector(name="Energy", description="Imported by CPR loader", source_id=1)
+    )
+    test_db.add(
+        Sector(name="Agriculture", description="Imported by CPR loader", source_id=1)
+    )
     test_db.commit()
 
     document1_payload = {
@@ -287,8 +439,8 @@ def test_document_detail(
         "responses": [{"name": "Mitigation", "description": "Imported by CPR loader"}],
         "hazards": [
             {"name": "some hazard", "description": "Imported by CPR loader"},
-            {"name": "some other hazard1", "description": "Imported by CPR loader"},
-            {"name": "some other hazard2", "description": "Imported by CPR loader"},
+            {"name": "some other hazard 1", "description": "Imported by CPR loader"},
+            {"name": "some other hazard 2", "description": "Imported by CPR loader"},
         ],
         "keywords": [
             {"name": "some keyword", "description": "Imported by CPR loader"},

--- a/backend/tests/routes/test_documents.py
+++ b/backend/tests/routes/test_documents.py
@@ -159,6 +159,7 @@ def test_post_documents(client, superuser_token_headers, test_db):
 
 
 def test_post_documents_fail(client, superuser_token_headers, test_db):
+    """Document creation should fail unless all referenced metadata already exists."""
 
     # ensure meta
     test_db.add(Source(name="may it be with you"))

--- a/makefile-docker.defs
+++ b/makefile-docker.defs
@@ -30,6 +30,10 @@ migrations_docker_backend:
 	# Create initial data in database
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend python3 app/initial_data.py
 
+cleanup_tables:
+	# Cleanup duplicate data
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm backend python3 scripts/cleanup_lookups.py
+
 migrations: migrations_docker_backend 
 
 %:


### PR DESCRIPTION
This PR does the following:
- closes off a bug that would create duplicate metadata (by limiting document creation to existing metadata fields)
- provides a script that cleans up duplicate keywords & instruments in an existing database
- completes an existing TODO so that documents & metadata links are created in a transaction

We should discuss how we should test a script that should probably be removed soon...