### PR TITLE
Get JSON logging working with alembic and app nicely

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -15,7 +15,8 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)  # type: ignore
+if "SKIP_ALEMBIC_LOGGING" not in os.environ.keys():
+    fileConfig(config.config_file_name, disable_existing_loggers=False)  # type: ignore
 
 # add your model's MetaData object here
 # for 'autogenerate' support
@@ -32,7 +33,6 @@ target_metadata = Base.metadata
 
 def get_url():
     db_url = os.environ["DATABASE_URL"]
-    print(f"DATABASE_URL={db_url}")
     return db_url
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,8 @@ from fastapi_pagination import add_pagination
 from slowapi.errors import RateLimitExceeded
 from slowapi.extension import _rate_limit_exceeded_handler
 from starlette.requests import Request
+from alembic.command import upgrade
+from alembic.config import Config
 
 from app.api.api_v1.routers.admin import admin_users_router
 from app.api.api_v1.routers.auth import auth_router
@@ -24,8 +26,8 @@ from app.core.auth import get_current_active_user, get_current_active_superuser
 from app.core.health import is_database_online
 from app.core.ratelimit import limiter
 from app.db.session import SessionLocal
-from alembic.command import upgrade
-from alembic.config import Config
+
+os.environ["SKIP_ALEMBIC_LOGGING"] = "1"
 
 # Clear existing log handlers so we always log in structured JSON
 root_logger = logging.getLogger()


### PR DESCRIPTION
How does this look?

Tested locally:

```
 $ alembic upgrade head
DATABASE_URL=postgresql://navigator:password@localhost:5432/navigator
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
```

With app:
```
$ python app/main.py 
{"written_at": "2022-08-12T14:18:48.538Z", "written_ts": 1660313928538854000, "msg": "Started server process [1136245]", "type": "log", "logger": "uvicorn.error", "thread": "MainThread", "level": "INFO", "module": "server", "line_no": 75, "correlation_id": "-"}
{"written_at": "2022-08-12T14:18:48.871Z", "written_ts": 1660313928871581000, "msg": "Waiting for application startup.", "type": "log", "logger": "uvicorn.error", "thread": "MainThread", "level": "INFO", "module": "on", "line_no": 45, "correlation_id": "-"}
{"written_at": "2022-08-12T14:18:48.882Z", "written_ts": 1660313928882989000, "msg": "Context impl PostgresqlImpl.", "type": "log", "logger": "alembic.runtime.migration", "thread": "MainThread", "level": "INFO", "module": "migration", "line_no": 204, "correlation_id": "-"}
{"written_at": "2022-08-12T14:18:48.883Z", "written_ts": 1660313928883377000, "msg": "Will assume transactional DDL.", "type": "log", "logger": "alembic.runtime.migration", "thread": "MainThread", "level": "INFO", "module": "migration", "line_no": 207, "correlation_id": "-"}
{"written_at": "2022-08-12T14:18:48.888Z", "written_ts": 1660313928888258000, "msg": "Application startup complete.", "type": "log", "logger": "uvicorn.error", "thread": "MainThread", "level": "INFO", "module": "on", "line_no": 59, "correlation_id": "-"}
{"written_at": "2022-08-12T14:18:48.889Z", "written_ts": 1660313928889059000, "msg": "Uvicorn running on http://0.0.0.0:8888 (Press CTRL+C to quit)", "type": "log", "logger": "uvicorn.error", "thread": "MainThread", "level": "INFO", "module": "server", "line_no": 206, "correlation_id": "-"}

```