### PR TITLE
bugfix/tsc version issue

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,3 +1,2 @@
 node_modules
-package-lock.json
 .next

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,8 +26,9 @@ WORKDIR /opt/node_app/app
 # user who runs the app.
 # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
 #USER node
-COPY --chown=node:node package.json package-lock.json* ./
-RUN npm install && npm cache clean --force && mv node_modules ../ && mkdir node_modules && chown node:node node_modules
+COPY --chown=node:node package.json package-lock.json ./
+
+RUN npm ci && npm cache clean --force && mv node_modules ../ && mkdir node_modules && chown node:node node_modules
 ENV PATH /opt/node_app/node_modules/.bin:$PATH
 
 COPY --chown=node:node . .

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,10 +35,6 @@
     "sass": "^1.45.0",
     "start-server-and-test": "^1.14.0",
     "tailwind-scrollbar": "^1.3.1",
-    "@types/node": "^12.12.21",
-    "@types/react": "^17.0.2",
-    "@types/react-dom": "^17.0.1",
-    "typescript": "^4.5.4",
     "uuid": "^8.3.2",
     "yup": "^0.32.11"
   },
@@ -51,6 +47,10 @@
     "eslint-config-next": "12.0.7",
     "eslint-config-prettier": "^8.3.0",
     "postcss-preset-env": "^7.0.2",
-    "tailwindcss": "^3.0.5"
+    "@types/node": "^12.12.21",
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.1",
+    "tailwindcss": "^3.0.5",
+    "typescript": "^4.5.4"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,10 @@
     "sass": "^1.45.0",
     "start-server-and-test": "^1.14.0",
     "tailwind-scrollbar": "^1.3.1",
+    "@types/node": "^12.12.21",
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.1",
+    "typescript": "^4.5.4",
     "uuid": "^8.3.2",
     "yup": "^0.32.11"
   },
@@ -42,15 +46,11 @@
     "@babel/core": "^7.16.5",
     "@babel/preset-env": "^7.16.5",
     "@tailwindcss/forms": "^0.5.0",
-    "@types/node": "^12.12.21",
-    "@types/react": "^17.0.2",
-    "@types/react-dom": "^17.0.1",
     "babel-eslint": "^10.1.0",
     "eslint": "8.4.1",
     "eslint-config-next": "12.0.7",
     "eslint-config-prettier": "^8.3.0",
     "postcss-preset-env": "^7.0.2",
-    "tailwindcss": "^3.0.5",
-    "typescript": "4.7.4"
+    "tailwindcss": "^3.0.5"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,6 @@
     "eslint-config-prettier": "^8.3.0",
     "postcss-preset-env": "^7.0.2",
     "tailwindcss": "^3.0.5",
-    "typescript": "^4.5.4"
+    "typescript": "4.7.4"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,14 +42,14 @@
     "@babel/core": "^7.16.5",
     "@babel/preset-env": "^7.16.5",
     "@tailwindcss/forms": "^0.5.0",
+    "@types/node": "^12.12.21",
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.1",
     "babel-eslint": "^10.1.0",
     "eslint": "8.4.1",
     "eslint-config-next": "12.0.7",
     "eslint-config-prettier": "^8.3.0",
     "postcss-preset-env": "^7.0.2",
-    "@types/node": "^12.12.21",
-    "@types/react": "^17.0.2",
-    "@types/react-dom": "^17.0.1",
     "tailwindcss": "^3.0.5",
     "typescript": "^4.5.4"
   }


### PR DESCRIPTION
This PR does 2 things:
- removes `package-lock.json` from docker ignore file - allowing docker to use it in the container
- uses `npm ci` instead of `npm install` to speed up the build by only using the lock file for deps