### PR TITLE
Remove instruments from filters and component

### DIFF
--- a/frontend/src/components/CountryLink.tsx
+++ b/frontend/src/components/CountryLink.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import Link from "next/link";
-import useNestedLookups from "@hooks/useNestedLookups";
+import useConfig from "@hooks/useConfig";
 import { getCountryId } from "@helpers/getCountryId";
 
 type TCountryLink = {
@@ -8,8 +8,9 @@ type TCountryLink = {
 };
 
 export const CountryLink: FC<TCountryLink> = ({ countryCode, children }) => {
-  const geosQuery = useNestedLookups("geographies", "", 2);
-  const { data: { data: { level2: countries = [] } = {} } = {} } = geosQuery;
+  const configQuery: any = useConfig("config");
+  const { data: { countries = [] } = {} } = configQuery;
+
   const countryId = getCountryId(countryCode, countries);
   if (!countryId) return <>{children}</>;
   return (

--- a/frontend/src/components/blocks/CountryHeader.tsx
+++ b/frontend/src/components/blocks/CountryHeader.tsx
@@ -1,5 +1,5 @@
 import { TGeographyStats, TGeography } from "@types";
-import useNestedLookups from "@hooks/useNestedLookups";
+import useConfig from "@hooks/useConfig";
 import Tooltip from "@components/tooltip";
 
 type TProps = {
@@ -7,8 +7,9 @@ type TProps = {
 };
 
 export const CountryHeader = ({ country }: TProps) => {
-  const geosQuery = useNestedLookups("geographies", "", 2);
-  const { data: { data: { level1: regions = [], level2: countries = [] } = {} } = {} } = geosQuery;
+  const configQuery: any = useConfig("config");
+  const { data: { regions = [], countries = [] } = {} } = configQuery;
+
   const countryGeography = countries.find((c: TGeography) => c.display_value === country.name);
 
   const getCountryRegion = () => {

--- a/frontend/src/components/blocks/SearchFilters.tsx
+++ b/frontend/src/components/blocks/SearchFilters.tsx
@@ -20,7 +20,6 @@ interface SearchFiltersProps {
   filteredCountries: object[];
   sectors: TSector[];
   documentTypes: object[];
-  instruments: object[];
 }
 
 const SearchFilters: React.FC<SearchFiltersProps> = React.memo(

--- a/frontend/src/pages/document/[docId].tsx
+++ b/frontend/src/pages/document/[docId].tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import useDocumentDetail from "@hooks/useDocumentDetail";
-import useSortAndStructure from "@hooks/useSortAndStructure";
 import Layout from "@components/layouts/Main";
 import Loader from "@components/Loader";
 import TextLink from "@components/nav/TextLink";
@@ -23,7 +22,6 @@ const DocumentCoverPage = () => {
   const [showFullSummary, setShowFullSummary] = useState(false);
   const [summary, setSummary] = useState("");
   const router = useRouter();
-  const structureData = useSortAndStructure();
 
   const documentQuery = useDocumentDetail(router.query.docId as string);
   const { data: { data: page } = {}, isFetching } = documentQuery;
@@ -157,7 +155,6 @@ const DocumentCoverPage = () => {
 
                   {page.keywords.length > 0 && <DocumentInfo id="keywords-tt" heading="Keywords" list={page.keywords} />}
                   {page.sectors.length > 0 && <DocumentInfo id="sectors-tt" heading="Sectors" list={page.sectors} />}
-                  {page.instruments.length > 0 && <DocumentInfo id="instruments-tt" heading="Instruments" list={structureData(page.instruments)} bulleted={true} />}
                   <div className="mt-8 border-t border-blue-100">
                     <h3 className="text-blue-700 mt-4">Source</h3>
                     <div className="flex items-end mt-4">

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import useSearchCriteria from "@hooks/useSearchCriteria";
 import useUpdateSearchCriteria from "@hooks/useUpdateSearchCriteria";
 import useUpdateSearch from "@hooks/useUpdateSearch";
-import useNestedLookups from "@hooks/useNestedLookups";
 import useUpdateCountries from "@hooks/useUpdateCountries";
 import Layout from "@components/layouts/LandingPage";
 import { Hero } from "@components/blocks/Hero";
@@ -30,13 +29,7 @@ const IndexPage = () => {
   when returning to this page from a previous search
   */
   const configQuery: any = useConfig("config");
-  const {
-            data: {
-                    geographies: geographies = [],
-                    regions: regions = [],
-                    countries: countries = [],
-                  } = {}
-        } = configQuery;
+  const { data: { geographies: geographies = [], regions: regions = [], countries: countries = [] } = {} } = configQuery;
 
   const handleSearchInput = (e, term) => {
     e.preventDefault();

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -10,11 +10,8 @@ import useUpdateSearchCriteria from "@hooks/useUpdateSearchCriteria";
 import useUpdateSearchFilters from "@hooks/useUpdateSearchFilters";
 import useUpdateCountries from "@hooks/useUpdateCountries";
 import useConfig from "@hooks/useConfig";
-import useNestedLookups from "@hooks/useNestedLookups";
-import useLookups from "@hooks/useLookups";
 import useFilteredCountries from "@hooks/useFilteredCountries";
 import useOutsideAlerter from "@hooks/useOutsideAlerter";
-import useSortAndStructure from "@hooks/useSortAndStructure";
 import Layout from "@components/layouts/Main";
 import LoaderOverlay from "@components/LoaderOverlay";
 import SearchForm from "@components/forms/SearchForm";
@@ -47,7 +44,6 @@ const Search = () => {
   const [noQuery, setNoQuery] = useState(true);
   const [categoryIndex, setCategoryIndex] = useState(0);
 
-  const structureData = useSortAndStructure();
   const updateSearchCriteria = useUpdateSearchCriteria();
   const updateSearchFilters = useUpdateSearchFilters();
   const updateDocument = useUpdateDocument();
@@ -65,16 +61,7 @@ const Search = () => {
 
   // get lookups/filters
   const configQuery: any = useConfig("config");
-  const {
-            data: {
-                    document_types: document_types = [],
-                    geographies: geographies = [],
-                    instruments: instruments = [],
-                    sectors: sectors = [],
-                    regions: regions = [],
-                    countries: countries = [],
-                  } = {}
-        } = configQuery;
+  const { data: { document_types: document_types = [], sectors: sectors = [], regions: regions = [], countries: countries = [] } = {} } = configQuery;
 
   const { data: filteredCountries } = useFilteredCountries(countries);
 
@@ -293,7 +280,7 @@ const Search = () => {
                     <div className="md:hidden absolute right-0 top-0">
                       <Close onClick={() => setShowFilters(false)} size="16" />
                     </div>
-                     {configQuery.isFetching ? (
+                    {configQuery.isFetching ? (
                       <p>Loading filters...</p>
                     ) : (
                       <SearchFilters
@@ -307,7 +294,6 @@ const Search = () => {
                         filteredCountries={filteredCountries}
                         sectors={sectors}
                         documentTypes={document_types}
-                        instruments={structureData(instruments)}
                       />
                     )}
                   </div>


### PR DESCRIPTION
Was an issue with old instruments collection vs. new. Wasn't being used so has been removed for now.

Also issue with country link due to switch to new config endpoint.