### PR TITLE
Improve search

### DIFF
--- a/backend/app/core/search.py
+++ b/backend/app/core/search.py
@@ -370,6 +370,7 @@ class QueryBuilder:
                                 OPENSEARCH_INDEX_NAME_KEY: {
                                     "query": query_string,
                                     "operator": "and",
+                                    "minimum_should_match": "2<66%",  # all terms if there are 2 or less, otherwise 66% of terms (rounded down)
                                 }
                             }
                         },
@@ -394,6 +395,7 @@ class QueryBuilder:
                                     "query": query_string,
                                     "boost": 3,
                                     "operator": "and",
+                                    "minimum_should_match": "2<66%",  # all terms if there are 2 or less, otherwise 66% of terms (rounded down)
                                 }
                             }
                         },
@@ -423,6 +425,7 @@ class QueryBuilder:
                                 "text": {
                                     "query": query_string,
                                     "operator": "and",
+                                    "minimum_should_match": "2<66%",  # all terms if there are 2 or less, otherwise 66% of terms (rounded down)
                                 },
                             }
                         },

--- a/backend/app/core/search.py
+++ b/backend/app/core/search.py
@@ -369,7 +369,7 @@ class QueryBuilder:
                             "match": {
                                 OPENSEARCH_INDEX_NAME_KEY: {
                                     "query": query_string,
-                                    "operator": "or",
+                                    "operator": "and",
                                 }
                             }
                         },

--- a/backend/app/core/search.py
+++ b/backend/app/core/search.py
@@ -369,6 +369,7 @@ class QueryBuilder:
                             "match": {
                                 OPENSEARCH_INDEX_NAME_KEY: {
                                     "query": query_string,
+                                    "operator": "or",
                                 }
                             }
                         },
@@ -391,7 +392,8 @@ class QueryBuilder:
                             "match": {
                                 OPENSEARCH_INDEX_DESCRIPTION_KEY: {
                                     "query": query_string,
-                                    "boost": 3,  # TODO: configure?
+                                    "boost": 3,
+                                    "operator": "and",
                                 }
                             }
                         },
@@ -420,6 +422,7 @@ class QueryBuilder:
                             "match": {
                                 "text": {
                                     "query": query_string,
+                                    "operator": "and",
                                 },
                             }
                         },


### PR DESCRIPTION
The issue with wildly irrelevant results ended up not being with semantic search queries, but was because the Opensearch `match` query does an `OR` on tokens by default, meaning we'd get false positives like 'military defence organisation' for 'flood defence', as both matched on 'flood'.

This PR changes all `OR` operators to `AND`, which excludes a lot of irrelevant summaries and text passages.

There's nothing to do to the search threshold as semantic search similarity doesn't currently match up to our definitions of relevant search results. This is slightly to do with passage quality, and slightly to do with the fact that we're using a general model.

Take this following set of passages and similarities to the query "energy prices", that i've put into buckets of correct and incorrect results for the search:

```
correct: 
70.98756408691406 -- Concerning the energy sector, the Vision has as a principal objective to ensure that by 2025 both the rural and urban populations have access to reliable, clean sources of energy and at competitive prices
74.38273620605469 -- ).The world today faces two main threats related to energy – inadequate and insecure supplies at affordable prices and global warming due to over-consumption of fossil fuels.The prospects for global energy markets heighten concerns about energy security and the impact of climate change on energy-dependent small island states such as Jamaica.As stated by the IEA, “The challenge for all countries is to put in motion a transition to a more secure, lower-carbon energy system, without undermining economic and social development.
69.68185424804688 -- business operations will be exposed to risks of rising prices for water, energy, materials, and waste disposal.The private sector has an interest – and an economic opportunity – in managing the natural capital portfolio wisely, as many of the goods and services supplied by ecosystems cannot be replaced at any reasonable cost.
70.33955383300781 -- We plan to raise the efficiency of the government’s support system and make the best use of its benefits by redirecting it and targeting eligible citizens and economic sectors. For example, we understand that providing subsidies with no clear eligibility criteria is a substantial obstacle to the energy sector’s competitiveness. Free market prices shall, in the long term, stimulate productivity and competitiveness among utility companies and open the door to investment and diversification of the energy mix in the Kingdom. We will also seek to set clear subsidy criteria based on the maturity of economic sectors, their ability to compete locally and internationally and their actual need for subsidies, without endangering promising and strategic sectors.

incorrect: 
75.83150482177734 -- of energy
75.09526824951172 -- energy sources
75.03023529052734 -- sustainable energy
74.73570251464844 -- energy linkages and issues
74.38256072998047 -- energy-related
74.35993957519531 -- energy and water
73.26209259033203 -- Consumers Price Index (CPI)
72.38282012939453 -- Quotable Value Quarterly House Price Index.
72.09774017333984 -- The higher subsidies for ECE are budgeted to cost $131.1 million in operating funding over the four-year forecast period. This is on top of the $105 million that we provided for the ECE
75.79498291015625 -- Energy Security
73.5206527709961 -- Fees
73.16166687011719 -- case costs
```