### PR TITLE
Add document name to the page title

### DIFF
--- a/frontend/src/pages/document/[docId].tsx
+++ b/frontend/src/pages/document/[docId].tsx
@@ -71,7 +71,7 @@ const DocumentCoverPage = () => {
   const sourceLogo = page?.source?.name === "CCLW" ? "lse-logo.png" : null;
 
   return (
-    <Layout title={`Climate Policy Radar | Document title`}>
+    <Layout title={`Climate Policy Radar | ${page?.name ?? 'Loading...'}`}>
       {isFetching || !page?.name ? (
         <Loading />
       ) : (


### PR DESCRIPTION
Ensure the HTML document contains a valid, dynamic page title.