### PR TITLE
FRO-117: Redirect solution for preserving CCLW SEO

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,5 @@
 # Note: it's optional to create a .env file for this example if building the app via docker-compose.
 NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1
 NEXT_PUBLIC_LOGIN_API_URL=http://localhost:8000/api/tokens
+
+NEXT_REDIRECT_FILE="default.csv"

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -9,8 +9,5 @@
     "titleBar.activeBackground": "#006FD6",
     "titleBar.activeForeground": "#ffffff"
   },
-  "scss.lint.unknownAtRules": "ignore",
-  "[javascript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  }
+  "scss.lint.unknownAtRules": "ignore"
 }

--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -9,5 +9,8 @@
     "titleBar.activeBackground": "#006FD6",
     "titleBar.activeForeground": "#ffffff"
   },
-  "scss.lint.unknownAtRules": "ignore"
+  "scss.lint.unknownAtRules": "ignore",
+  "[javascript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -12,7 +12,7 @@ const nextConfig = {
   },
   pageExtensions: ["tsx", "ts"],
   async redirects() {
-    const std_redirects = [
+    const standardRedirects = [
       {
         source: '/auth/:id*',
         destination: '/',
@@ -35,10 +35,8 @@ const nextConfig = {
       },
     ];
 
-    return std_redirects.concat(await getRedirectsFromCsv(REDIRECT_FILE)) ;
+    return standardRedirects.concat(await getRedirectsFromCsv(REDIRECT_FILE));
   },
 }
 
 export default nextConfig
-
-

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -2,7 +2,7 @@
  * @type {import('next').NextConfig}
  */
 
-import getRedirectsFromCsv from "./redirects/reader.mjs"
+import read from "./redirects/reader.mjs"
 const REDIRECT_FILE = process.env.NEXT_REDIRECT_FILE || "default.csv"
 
 const nextConfig = {
@@ -35,7 +35,7 @@ const nextConfig = {
       },
     ];
 
-    return standardRedirects.concat(await getRedirectsFromCsv(REDIRECT_FILE));
+    return standardRedirects.concat(await read(REDIRECT_FILE));
   },
 }
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,11 +1,18 @@
-module.exports = {
+/**
+ * @type {import('next').NextConfig}
+ */
+
+import getRedirectsFromCsv from "./redirects/reader.mjs"
+const REDIRECT_FILE = process.env.NEXT_REDIRECT_FILE || "default.csv"
+
+const nextConfig = {
   i18n: {
     locales: ["en", "fr"],
     defaultLocale: "en",
   },
   pageExtensions: ["tsx", "ts"],
   async redirects() {
-    return [
+    const std_redirects = [
       {
         source: '/auth/:id*',
         destination: '/',
@@ -26,6 +33,12 @@ module.exports = {
         destination: '/',
         permanent: true,
       },
-    ]
+    ];
+
+    return std_redirects.concat(await getRedirectsFromCsv(REDIRECT_FILE)) ;
   },
-};
+}
+
+export default nextConfig
+
+

--- a/frontend/redirects/default.csv
+++ b/frontend/redirects/default.csv
@@ -1,0 +1,1 @@
+/testing-redirects,/,on

--- a/frontend/redirects/reader.mjs
+++ b/frontend/redirects/reader.mjs
@@ -1,0 +1,46 @@
+import { createReadStream } from "fs";
+import readLine from "readline";
+import { join } from "path";
+
+const FALSE_VALUES = [ "0", "OFF", "NO", "FALSE"];
+
+function toBool(value) {
+  if (FALSE_VALUES.includes(value.toUpperCase())) {
+    return false;
+  }
+  return true;
+}
+
+async function getRedirectsFromCsv(filename) {
+  const redirectFile = join("redirects", filename);
+  const stream = createReadStream(redirectFile);
+
+  const lineReader = readLine.createInterface({ input: stream });
+  let data = [];
+
+  const dataReady = new Promise((resolve, reject) => {
+    lineReader.on("line", (row) => {
+      const rowValues = row.split(",");
+      if (rowValues.length != 3) {
+        reject(`ERROR: CSV file ${redirectFile} does not have 3 values on line: ${data.length+1}`)
+      }
+      data.push({
+        source: rowValues[0],
+        destination: rowValues[1],
+        permanent: toBool(rowValues[2]),
+      });
+    });
+  
+    lineReader.on("close", () => {
+      resolve(data);
+    });
+
+    lineReader.on("error", () => {
+      reject(`ERROR: Reading redirect file named: ${redirectFile}`);
+    });
+  });
+
+  return dataReady;
+}
+
+export default getRedirectsFromCsv;

--- a/frontend/redirects/reader.mjs
+++ b/frontend/redirects/reader.mjs
@@ -2,27 +2,37 @@ import { createReadStream } from "fs";
 import readLine from "readline";
 import { join } from "path";
 
-const FALSE_VALUES = [ "0", "OFF", "NO", "FALSE"];
+const FALSE_VALUES = ["0", "OFF", "NO", "FALSE"];
 
-function toBool(value) {
-  if (FALSE_VALUES.includes(value.toUpperCase())) {
-    return false;
-  }
-  return true;
-}
 
-async function getRedirectsFromCsv(filename) {
-  const redirectFile = join("redirects", filename);
-  const stream = createReadStream(redirectFile);
+/**
+ * read - Reads redirect definitions given the filename - currently only CSV.
+ * 
+ * @param {*} filename - Only the filename which should be a file in the top-level "redirects" folder
+ * @returns Promise to an array of redirects
+ */
+const read = (filename) => {
 
-  const lineReader = readLine.createInterface({ input: stream });
-  let data = [];
+  /**
+   * readFromCSV - Reads redirects from file - for use by a Promise.
+   * 
+   * @param {*} redirectFile - file to read from.
+   * @param {*} resolve - calls the function to return the array of redirects.
+   * @param {*} reject - calls this function when an error occurs with a string represtation of the error.
+   */
+  function readFromCSV(redirectFile, resolve, reject) {
 
-  const dataReady = new Promise((resolve, reject) => {
+    // toBool - returns a boolean given a string
+    const toBool = (value) => !(FALSE_VALUES.includes(value.toUpperCase()));
+
+    const stream = createReadStream(redirectFile);
+    const lineReader = readLine.createInterface({ input: stream });
+    let data = [];
+
     lineReader.on("line", (row) => {
       const rowValues = row.split(",");
       if (rowValues.length != 3) {
-        reject(`ERROR: CSV file ${redirectFile} does not have 3 values on line: ${data.length+1}`)
+        reject(`ERROR: CSV file ${redirectFile} does not have 3 values on line: ${data.length + 1}`)
       }
       data.push({
         source: rowValues[0],
@@ -30,7 +40,7 @@ async function getRedirectsFromCsv(filename) {
         permanent: toBool(rowValues[2]),
       });
     });
-  
+
     lineReader.on("close", () => {
       resolve(data);
     });
@@ -38,9 +48,10 @@ async function getRedirectsFromCsv(filename) {
     lineReader.on("error", () => {
       reject(`ERROR: Reading redirect file named: ${redirectFile}`);
     });
-  });
+  }
 
-  return dataReady;
+  return new Promise((resolve, reject) => readFromCSV(join("redirects", filename), resolve, reject));
 }
 
-export default getRedirectsFromCsv;
+
+export default read;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1029,9 +1029,14 @@
   "resolved" "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-12.0.7.tgz"
   "version" "12.0.7"
 
-"@next/swc-darwin-x64@12.0.7":
-  "integrity" "sha512-km+6Rx6TvbraoQ1f0MXa69ol/x0RxzucFGa2OgZaYJERas0spy0iwW8hpASsGcf597D8VRW1x+R2C7ZdjVBSTw=="
-  "resolved" "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.7.tgz"
+"@next/swc-linux-x64-gnu@12.0.7":
+  "integrity" "sha512-9ITyp6s6uGVKNx3C/GP7GrYycbcwTADG7TdIXzXUxOOZORrdB1GNg3w/EL3Am4VMPPEpO6v1RfKo2IKZpVKfTA=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.7.tgz"
+  "version" "12.0.7"
+
+"@next/swc-linux-x64-musl@12.0.7":
+  "integrity" "sha512-C+k+cygbIZXYfc+Hx2fNPUBEg7jzio+mniP5ywZevuTXW14zodIfQ3ZMoMJR8EpOVvYpjWFk2uAjiwqgx8vo/g=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.7.tgz"
   "version" "12.0.7"
 
 "@nodelib/fs.scandir@2.1.5":
@@ -1828,13 +1833,6 @@
   "integrity" "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
   "resolved" "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   "version" "2.2.0"
-
-"bindings@^1.5.0":
-  "integrity" "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="
-  "resolved" "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
-  "version" "1.5.0"
-  dependencies:
-    "file-uri-to-path" "1.0.0"
 
 "bluebird@^3.5.5", "bluebird@3.7.2":
   "integrity" "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
@@ -3191,11 +3189,6 @@
   dependencies:
     "flat-cache" "^3.0.4"
 
-"file-uri-to-path@1.0.0":
-  "integrity" "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-  "resolved" "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
-  "version" "1.0.0"
-
 "fill-range@^4.0.0":
   "integrity" "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ=="
   "resolved" "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz"
@@ -3350,19 +3343,6 @@
   "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
-
-"fsevents@^1.2.7":
-  "integrity" "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
-  "version" "1.2.13"
-  dependencies:
-    "bindings" "^1.5.0"
-    "nan" "^2.12.1"
-
-"fsevents@~2.3.1", "fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
 
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
@@ -4539,11 +4519,6 @@
   "integrity" "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
   "resolved" "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   "version" "2.1.2"
-
-"nan@^2.12.1":
-  "integrity" "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
-  "resolved" "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz"
-  "version" "2.16.0"
 
 "nano-time@1.0.0":
   "integrity" "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8="


### PR DESCRIPTION
This adds to the configuration a set of redirects that are loaded in from a CSV at app startup

This CSV will take the following format:
```
source, destination, permanent
/test, /, false
```

Where permanent is true/false given:

> Why does Next.js use 307 and 308? Traditionally a 302 was used for a temporary redirect, and a 301 for a permanent redirect, but many browsers changed the request method of the redirect to GET, regardless of the original method. For example, if the browser made a request to POST /v1/users which returned status code 302 with location /v2/users, the subsequent request might be GET /v2/users instead of the expected POST /v2/users. Next.js uses the 307 temporary redirect, and 308 permanent redirect status codes to explicitly preserve the request method used.

*Source*: https://nextjs.org/docs/api-reference/next.config.js/redirects 
