### PR TITLE
Make text block page and coordinates optional in opensearch response

### DIFF
--- a/backend/app/api/api_v1/schemas/search.py
+++ b/backend/app/api/api_v1/schemas/search.py
@@ -72,8 +72,8 @@ class SearchResponseDocumentPassage(BaseModel):
 
     text: str
     text_block_id: str
-    text_block_page: int
-    text_block_coords: List[Coord]
+    text_block_page: Optional[int]
+    text_block_coords: Optional[List[Coord]]
 
 
 class SearchResponseDocument(BaseModel):


### PR DESCRIPTION
For HTMLs. See https://github.com/climatepolicyradar/navigator-search-indexer/pull/23