### PR TITLE
Feature/robots txt sitemap

### DIFF
--- a/frontend/src/pages/robots.txt.ts
+++ b/frontend/src/pages/robots.txt.ts
@@ -2,16 +2,14 @@ const crawlableRobotsTxt = `User-agent: *\nAllow: /`;
 
 const uncrawlableRobotsTxt = `User-agent: *\nDisallow: /`;
 
-const isProd = () => {
-  return process.env.API_URL && !process.env.API_URL.includes("dev");
-};
-
-function Robots() {}
+function Robots() { }
 
 export async function getServerSideProps({ res }) {
   res.setHeader("Content-Type", "text/plan");
-  res.write(isProd() ? crawlableRobotsTxt : uncrawlableRobotsTxt);
+  res.write(process.env.ROBOTS === "true" ? crawlableRobotsTxt : uncrawlableRobotsTxt);
   res.end();
+
+  console.log(process.env.ROBOTS);
 
   return {
     props: {},

--- a/frontend/src/pages/robots.txt.ts
+++ b/frontend/src/pages/robots.txt.ts
@@ -9,8 +9,6 @@ export async function getServerSideProps({ res }) {
   res.write(process.env.ROBOTS === "true" ? crawlableRobotsTxt : uncrawlableRobotsTxt);
   res.end();
 
-  console.log(process.env.ROBOTS);
-
   return {
     props: {},
   };

--- a/frontend/src/pages/sitemap.txt.ts
+++ b/frontend/src/pages/sitemap.txt.ts
@@ -26,7 +26,6 @@ async function getGeographyIds(): Promise<string[]> {
 
 async function getGeographyPages(res: any, hostname: string): Promise<string[]> {
   const slug_list: string[] = await getGeographyIds();
-  // TODO: Fix this: https://linear.app/climate-policy-radar/issue/FRO-114/replace-hardcoded-hostname-with-one-injected-at-deploytime
   return slug_list.map((geo_slug: string) => `${hostname ?? ''}/geographies/${geo_slug}`);
 }
 

--- a/frontend/src/pages/sitemap.txt.ts
+++ b/frontend/src/pages/sitemap.txt.ts
@@ -8,27 +8,32 @@ function extractGeographyIds(config: TGeographyConfig): number[] {
   return [config.node.id].concat(children_ids);
 }
 
+function extractGeographySlugs(config: TGeographyConfig): string[] {
+  const children_slugs: string[] = config.children.flatMap((node): string[] => (extractGeographySlugs(node)));
+  return [config.node.slug].concat(children_slugs);
+}
+
 async function fetchGeographies(): Promise<TGeographyConfig[]> {
   const client = new ApiClient();
   const { data: data } = await client.get(`/config/`, null);
   return data.metadata.CCLW.geographies;
 }
 
-async function getGeographyIds(): Promise<number[]> {
+async function getGeographyIds(): Promise<string[]> {
   const geographyData: TGeographyConfig[] = await fetchGeographies();
-  return geographyData.flatMap((item: TGeographyConfig) => extractGeographyIds(item));
+  return geographyData.flatMap((item: TGeographyConfig) => extractGeographySlugs(item));
 }
 
-async function getGeographyPages(res: any): Promise<string[]> {
-  const id_list: number[] = await getGeographyIds();
+async function getGeographyPages(res: any, hostname: string): Promise<string[]> {
+  const slug_list: string[] = await getGeographyIds();
   // TODO: Fix this: https://linear.app/climate-policy-radar/issue/FRO-114/replace-hardcoded-hostname-with-one-injected-at-deploytime
-  return id_list.map((geo_id: number) => `https://app.climatepolicyradar.org/geographies/${geo_id}`);
+  return slug_list.map((geo_slug: string) => `${hostname ?? ''}/geographies/${geo_slug}`);
 }
 
 export async function getServerSideProps({ res }) {
 
   res.setHeader("Content-Type", "text/plain");
-  res.write((await getGeographyPages(res)).join('\n'));
+  res.write((await getGeographyPages(res, process.env.HOSTNAME)).join('\n'));
   res.end();
 
   return {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -73,6 +73,7 @@ export type TGeographyConfigNode = {
   value: string;
   type: string;
   parent_id: number;
+  slug: string;
 };
 
 export type TGeographyConfig = {


### PR DESCRIPTION
Requires two new env vars to be created:
- ROBOTS: this needs to be a string of "true" in order to have an effect. It will allow the site to be crawled.
- HOSTNAME: this is to be used when creating the sitemap

Sitemap is now generating the geography pages using their slug rather than ID.