### PR TITLE
Rewrite landing page animation

### DIFF
--- a/frontend/e2e/cypress/e2e/landing/landing-page.spec.js
+++ b/frontend/e2e/cypress/e2e/landing/landing-page.spec.js
@@ -5,20 +5,31 @@ describe("Landing page", () => {
     cy.visit("/");
   });
 
-  it("should see placeholder text which should clear after clicking input", () => {
-    // wait for text animation to finish
-    cy.wait(3000);
-
+  it("should see placeholder text", () => {
     cy.get('[data-cy="search-input"]')
       .invoke("attr", "placeholder")
       .then((text) => {
         expect(text).to.equal("Search full text of 3000+ laws and policies");
       });
+  });
+
+  it("should display a placeholder animated element", () => {
+    cy.get(".search-animated-placeholder").should("be.visible");
+  });
+
+  it("should hide the animated placeholder when the input is interacted with", () => {
+    cy.get('[data-cy="search-input"]').click();
+    cy.get(".search-animated-placeholder").should("not.exist");
+  });
+
+  it("should display the value that is typed in", () => {
     cy.get('[data-cy="search-input"]')
-      .click()
-      .invoke("attr", "placeholder")
-      .then((phText) => {
-        expect(phText).to.be.empty;
+      .clear()
+      .type("This is a test input")
+      .invoke("val")
+      .then((val) => {
+        const myVal = val;
+        expect(myVal).to.equal("This is a test input");
       });
   });
 });

--- a/frontend/src/components/forms/LandingSearchForm.tsx
+++ b/frontend/src/components/forms/LandingSearchForm.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useContext } from "react";
-import { StartTextAnimation } from "@utils/typewriter";
 import Close from "../buttons/Close";
 import { SearchIcon } from "../svg/Icons";
 import { SearchDropdown } from "./SearchDropdown";
@@ -14,7 +13,7 @@ interface SearchFormProps {
 const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchFormProps) => {
   const [term, setTerm] = useState("");
   const [formFocus, setFormFocus] = useState(false);
-  const inputRef = useRef(null);
+  const [showAnimation, setShowAnimation] = useState(true);
   const formRef = useRef(null);
   const theme = useContext(ThemeContext);
 
@@ -22,9 +21,14 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchForm
     setTerm("");
   };
 
-  const clearPlaceholder = () => {
+  const clearPlaceholderAnimation = () => {
     if (theme !== "cpr") return;
-    inputRef.current.placeholder = "";
+    setShowAnimation(false);
+  };
+
+  const showPlaceholderAnimation = () => {
+    if (theme !== "cpr") return;
+    if (term.length === 0) setShowAnimation(true);
   };
 
   const onChange = (e) => {
@@ -34,13 +38,6 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchForm
   useEffect(() => {
     if (input) setTerm(input);
   }, [input]);
-
-  useEffect(() => {
-    if (inputRef.current) {
-      const text = [placeholder ?? "Search full text of 3000+ laws and policies"];
-      StartTextAnimation(0, text, inputRef.current);
-    }
-  }, [inputRef, placeholder]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -62,12 +59,24 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchForm
       ? "placeholder:text-white pr-16 text-2xl bg-transparent border-t-0 border-l-0 border-r-0 border-white border-b-2 focus:border-white focus:ring-0 w-full"
       : "py-3 pl-6 pr-16 w-full text-indigo-400 focus:ring-0";
 
-  const buttonCssClass = theme === "cpr" ? "absolute top-0 right-0 -mt-1" : "absolute right-0 h-full pr-2 text-grey-700";
+  const buttonCssClass = theme === "cpr" ? "absolute top-0 right-0 h-full" : "absolute right-0 h-full pr-2 text-grey-700";
+  const displayPlaceholder = placeholder ?? "Search full text of 3000+ laws and policies";
 
   return (
     <form data-cy="search-form" ref={formRef} onSubmit={(e) => e.preventDefault()}>
       <div className={`max-w-screen-lg mx-auto flex items-stretch relative ${wrapperCssClass}`}>
-        <input data-cy="search-input" ref={inputRef} type="search" className={inputCssClass} value={term} onChange={onChange} onClick={clearPlaceholder} />
+        <input
+          id="landingPage-searchInput"
+          data-cy="search-input"
+          type="search"
+          className={inputCssClass}
+          value={term}
+          onChange={onChange}
+          onFocus={clearPlaceholderAnimation}
+          onBlur={showPlaceholderAnimation}
+          placeholder={displayPlaceholder}
+        />
+        {theme === "cpr" && showAnimation && <div className="search-animated-placeholder">{displayPlaceholder}</div>}
         {theme === "cpr" && term.length > 0 && (
           <div data-cy="search-clear-button" className="flex mx-2 shrink-0 absolute top-0 right-0 mr-20 z-20 h-full items-center">
             <Close onClick={clearSearch} size="16" />

--- a/frontend/src/components/forms/LandingSearchForm.tsx
+++ b/frontend/src/components/forms/LandingSearchForm.tsx
@@ -76,7 +76,7 @@ const LandingSearchForm = ({ placeholder, input, handleSearchInput }: SearchForm
           onBlur={showPlaceholderAnimation}
           placeholder={displayPlaceholder}
         />
-        {theme === "cpr" && showAnimation && <div className="search-animated-placeholder">{displayPlaceholder}</div>}
+        {theme === "cpr" && showAnimation && term.length === 0 && <div className="search-animated-placeholder">{displayPlaceholder}</div>}
         {theme === "cpr" && term.length > 0 && (
           <div data-cy="search-clear-button" className="flex mx-2 shrink-0 absolute top-0 right-0 mr-20 z-20 h-full items-center">
             <Close onClick={clearSearch} size="16" />

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -329,8 +329,12 @@ ul li.selected {
   }
   table {
     @apply text-left my-6;
-    th { @apply p-2; }
-    td { @apply border border-gray-300 p-2 align-top; }
+    th {
+      @apply p-2;
+    }
+    td {
+      @apply border border-gray-300 p-2 align-top;
+    }
   }
 }
 .pdf-container {
@@ -416,5 +420,63 @@ ul li.selected {
 .accordian__content {
   p {
     @apply mb-2;
+  }
+}
+
+#landingPage-searchInput {
+  &::-webkit-input-placeholder {
+    /* WebKit browsers */
+    color: transparent;
+  }
+  &:-moz-placeholder {
+    /* Mozilla Firefox 4 to 18 */
+    color: transparent;
+  }
+  &::-moz-placeholder {
+    /* Mozilla Firefox 19+ */
+    color: transparent;
+  }
+  &:-ms-input-placeholder {
+    /* Internet Explorer 10+ */
+    color: transparent;
+  }
+  &::placeholder {
+    color: transparent;
+  }
+}
+
+.search-animated-placeholder {
+  @apply pr-1 text-2xl bg-transparent;
+  overflow: hidden;
+  position: absolute;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  z-index: -1;
+  height: 75%;
+  border-right: 2px solid;
+  white-space: nowrap;
+  padding-left: 0.75rem;
+  animation: typing 3s steps(60, end), blink-caret 0.75s step-end infinite;
+}
+
+/* The typing effect */
+@keyframes typing {
+  from {
+    width: 0;
+  }
+  to {
+    width: 50%;
+  }
+}
+
+/* The typewriter cursor effect */
+@keyframes blink-caret {
+  from,
+  to {
+    border-color: transparent;
+  }
+  50% {
+    border-color: white;
   }
 }


### PR DESCRIPTION
I’ve re-written the “typewriter” animation on the homepage to use css animations rather than manipulating the input’s placeholder as it was before. This means we will see the end of that annoying flakey front-end test that fails due to timing issues when running in CI.

I’ve also written some much better e-2-e tests on this element to test that the animated element hides when the user starts typing, and that what they type is being logged. Just a start, but feels to have that 1% more coverage.