### PR TITLE
Disable search animation on mobile screens

### DIFF
--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -424,40 +424,46 @@ ul li.selected {
 }
 
 #landingPage-searchInput {
-  &::-webkit-input-placeholder {
-    /* WebKit browsers */
-    color: transparent;
-  }
-  &:-moz-placeholder {
-    /* Mozilla Firefox 4 to 18 */
-    color: transparent;
-  }
-  &::-moz-placeholder {
-    /* Mozilla Firefox 19+ */
-    color: transparent;
-  }
-  &:-ms-input-placeholder {
-    /* Internet Explorer 10+ */
-    color: transparent;
-  }
-  &::placeholder {
-    color: transparent;
+  @screen md {
+    &::-webkit-input-placeholder {
+      /* WebKit browsers */
+      color: transparent;
+    }
+    &:-moz-placeholder {
+      /* Mozilla Firefox 4 to 18 */
+      color: transparent;
+    }
+    &::-moz-placeholder {
+      /* Mozilla Firefox 19+ */
+      color: transparent;
+    }
+    &:-ms-input-placeholder {
+      /* Internet Explorer 10+ */
+      color: transparent;
+    }
+    &::placeholder {
+      color: transparent;
+    }
   }
 }
 
 .search-animated-placeholder {
-  @apply pr-1 text-2xl bg-transparent;
-  overflow: hidden;
-  position: absolute;
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: center;
-  z-index: -1;
-  height: 75%;
-  border-right: 2px solid;
-  white-space: nowrap;
-  padding-left: 0.75rem;
-  animation: typing 3s steps(60, end), blink-caret 0.75s step-end infinite;
+  display: none;
+  @screen md {
+    @apply pr-1 text-2xl bg-transparent;
+    overflow: hidden;
+    position: absolute;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    z-index: -1;
+    height: 75%;
+    border-right: 2px solid;
+    white-space: nowrap;
+    padding-left: 0.75rem;
+    animation: typing 3s steps(60, end), blink-caret 0.75s step-end infinite;
+    max-width: 75%;
+  }
 }
 
 /* The typing effect */


### PR DESCRIPTION
The width of the animated container is breaking the layout on mobile devices because there is not enough screen width to house the placeholder.

So for mobile devices they will get the default placeholder.

Worth reviewing the placeholder for small screens in future as I'm not sure how much value it is to only see the first 30 characters.