### PR TITLE
Re-enable default prefetch on links

### DIFF
--- a/frontend/src/components/CountryLink.tsx
+++ b/frontend/src/components/CountryLink.tsx
@@ -16,7 +16,7 @@ export const CountryLink: FC<TCountryLink> = ({ countryCode, className = "", chi
   const slug = getCountrySlug(countryCode, countries);
   if (!slug) return <>{children}</>;
   return (
-    <Link href={`/geographies/${slug}`} className={`flex items-center underline ${className}`} prefetch={false} passHref>
+    <Link href={`/geographies/${slug}`} className={`flex items-center underline ${className}`} passHref>
       {children}
     </Link>
   );

--- a/frontend/src/components/document/DocumentListItem.tsx
+++ b/frontend/src/components/document/DocumentListItem.tsx
@@ -36,7 +36,6 @@ export const DocumentListItem: FC<TProps> = ({ children, listItem }) => {
           <Link
             href={`/document/${slug}`}
             className={`text-left text-blue-500 font-medium text-lg transition duration-300 leading-tight hover:underline ${theme === "cpr" ? "underline" : ""}`}
-            prefetch={false}
             passHref
           >
             {getDocumentTitle(name, postfix)}


### PR DESCRIPTION
Prefetch was removed when we ran into issues with caching.

We've now looked into it further and there is no need to remove it.